### PR TITLE
Feature/af_callbacks_functions

### DIFF
--- a/dbt_af/__init__.py
+++ b/dbt_af/__init__.py
@@ -3,6 +3,6 @@ __all__ = [
     'conf',
 ]
 
-__version__ = '0.5.3'
+__version__ = '0.6.0'
 
 from . import conf, dags  # noqa

--- a/dbt_af/builder/dag_components.py
+++ b/dbt_af/builder/dag_components.py
@@ -37,7 +37,7 @@ class DagComponent:
         self.model_task: Optional[DbtRun | DbtKubernetesPodOperator] = None
         self.task_group: Optional[TaskGroup] = None
         self.af_sensor_endpoint: Optional[EmptyOperator | DbtRun | DbtKubernetesPodOperator] = None
-        self._af_callbacks: dict[str, Callable] = {}
+        self._af_callbacks: dict[str, list[Optional[Callable]]] = {}
 
     @property
     def depends_on(self) -> list['DagComponent']:
@@ -47,7 +47,7 @@ class DagComponent:
     def safe_name(self) -> str:
         return self.name.replace('.', '__')
 
-    def add_af_callbacks(self, callbacks: dict[str, Callable]):
+    def add_af_callbacks(self, callbacks: dict[str, list[Optional[Callable]]]):
         self._af_callbacks.update(callbacks)
 
     def add_dependency(self, dep: 'DagComponent'):

--- a/dbt_af/builder/dag_components.py
+++ b/dbt_af/builder/dag_components.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Callable, Generator, Optional
+from typing import Generator, Optional
 
 from airflow.operators.empty import EmptyOperator
 from airflow.utils.task_group import TaskGroup
@@ -37,7 +37,7 @@ class DagComponent:
         self.model_task: Optional[DbtRun | DbtKubernetesPodOperator] = None
         self.task_group: Optional[TaskGroup] = None
         self.af_sensor_endpoint: Optional[EmptyOperator | DbtRun | DbtKubernetesPodOperator] = None
-        self._af_callbacks: dict[str, list[Optional[Callable]]] = {}
+        self._af_callbacks: dict[str, list[Optional[callable]]] = {}
 
     @property
     def depends_on(self) -> list['DagComponent']:
@@ -47,7 +47,7 @@ class DagComponent:
     def safe_name(self) -> str:
         return self.name.replace('.', '__')
 
-    def add_af_callbacks(self, callbacks: dict[str, list[Optional[Callable]]]):
+    def add_af_callbacks(self, callbacks: dict[str, list[Optional[callable]]]):
         self._af_callbacks.update(callbacks)
 
     def add_dependency(self, dep: 'DagComponent'):

--- a/dbt_af/common/af_callbacks.py
+++ b/dbt_af/common/af_callbacks.py
@@ -1,0 +1,29 @@
+from typing import Optional
+from collections.abc import Iterable
+
+from dbt_af.conf import Config
+from dbt_af.integrations.mcd import prepare_mcd_callbacks
+from dbt_af.integrations.af_callbacks import prepare_custom_af_callbacks
+
+
+def merge_dicts_by_key(*dicts: dict) -> dict:
+    merged_dict = dict()
+
+    for d in dicts:
+        for key, value in d.items():
+            merged_dict.setdefault(key, [])
+            if isinstance(value, Iterable):
+                merged_dict[key].extend(list(value))
+            else:
+                merged_dict[key].append(value)
+    return dict(merged_dict)
+
+
+def af_custom_callbacks(config: Config) -> tuple[dict[str, list[Optional[callable]]], dict[str, list[Optional[callable]]]]:
+    mcd_dag_callbacks, mcd_task_callbacks = prepare_mcd_callbacks(config)
+    airflow_dag_callbacks, airflow_task_callbacks = prepare_custom_af_callbacks(config)
+
+    dag_callbacks = merge_dicts_by_key(mcd_dag_callbacks, airflow_dag_callbacks)
+    task_callbacks = merge_dicts_by_key(mcd_task_callbacks, airflow_task_callbacks)
+
+    return dag_callbacks, task_callbacks

--- a/dbt_af/conf/__init__.py
+++ b/dbt_af/conf/__init__.py
@@ -5,6 +5,7 @@ from dbt_af.conf.config import (
     K8sConfig,
     MCDIntegrationConfig,
     TableauIntegrationConfig,
+    AfCallbacksConfig
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     'K8sConfig',
     'MCDIntegrationConfig',
     'TableauIntegrationConfig',
+    'AfCallbacksConfig'
 ]

--- a/dbt_af/conf/__init__.py
+++ b/dbt_af/conf/__init__.py
@@ -5,7 +5,7 @@ from dbt_af.conf.config import (
     K8sConfig,
     MCDIntegrationConfig,
     TableauIntegrationConfig,
-    AfCallbacksConfig
+    CustomAfCallbacksConfig
 )
 
 __all__ = [
@@ -15,5 +15,5 @@ __all__ = [
     'K8sConfig',
     'MCDIntegrationConfig',
     'TableauIntegrationConfig',
-    'AfCallbacksConfig'
+    'CustomAfCallbacksConfig'
 ]

--- a/dbt_af/conf/config.py
+++ b/dbt_af/conf/config.py
@@ -6,7 +6,7 @@ import pendulum
 
 
 @attrs.define(frozen=True)
-class AfCallbacksConfig:
+class CustomAfCallbacksConfig:
     """
     Config to define callbacks functions for airflow DAGs and tasks
 
@@ -19,14 +19,14 @@ class AfCallbacksConfig:
     :param dag_sla_miss_callback: sla miss callback function for DAG (invoked when a task misses its defined SLA)
     """
 
-    task_on_success_callback: callable = attrs.field(default=None)
-    task_on_failure_callback: callable = attrs.field(default=None)
-    task_on_retry_callback: callable = attrs.field(default=None)
-    task_on_execute_callback: callable = attrs.field(default=None)
+    task_on_success_callback: tuple[callable] = attrs.field(factory=tuple)
+    task_on_failure_callback: tuple[callable] = attrs.field(factory=tuple)
+    task_on_retry_callback: tuple[callable] = attrs.field(factory=tuple)
+    task_on_execute_callback: tuple[callable] = attrs.field(factory=tuple)
 
-    dag_on_failure_callback: callable = attrs.field(default=None)
-    dag_on_success_callback: callable = attrs.field(default=None)
-    dag_sla_miss_callback: callable = attrs.field(default=None)
+    dag_on_failure_callback: tuple[callable] = attrs.field(factory=tuple)
+    dag_on_success_callback: tuple[callable] = attrs.field(factory=tuple)
+    dag_sla_miss_callback: tuple[callable] = attrs.field(factory=tuple)
 
 
 @attrs.define(frozen=True)
@@ -246,7 +246,7 @@ class Config:
     use_dbt_target_specific_pools: bool = attrs.field(default=True)
 
     # airflow callbacks config
-    af_callbacks: Optional[AfCallbacksConfig] = attrs.field(default=None)
+    af_callbacks: Optional[CustomAfCallbacksConfig] = attrs.field(default=None)
 
     # Monte Carlo Data integration
     mcd: Optional[MCDIntegrationConfig] = attrs.field(default=None)

--- a/dbt_af/conf/config.py
+++ b/dbt_af/conf/config.py
@@ -227,6 +227,7 @@ class Config:
         created for each dbt target with pattern `dbt_{target_name}`; if False, then only the default pool will be used
     :param af_callbacks: config with callback functions for airflow DAGs and tasks
     :param mcd: config for mcd integration; must be installed as extra dependency
+    :params tableau: config for Tableau integration
     :param k8s: settings for k8s operators
     """
 

--- a/dbt_af/conf/config.py
+++ b/dbt_af/conf/config.py
@@ -6,6 +6,30 @@ import pendulum
 
 
 @attrs.define(frozen=True)
+class AfCallbacksConfig:
+    """
+    Config to define callbacks functions for airflow DAGs and tasks
+
+    :param task_on_success_callback: success callback function for task (invoked when the task succeeds)
+    :param task_on_failure_callback: failure callback function for task (invoked when the airflow task fails)
+    :param task_on_retry_callback: retry callback function for task (invoked when the task is up for retry)
+    :param task_on_execute_callback: execute callback function for task (invoked right before task begins executing)
+    :param dag_on_failure_callback: failure callback function for DAG (invoked when the airflow task fails)
+    :param dag_on_success_callback: success callback function for DAG (invoked when the task succeeds)
+    :param dag_sla_miss_callback: sla miss callback function for DAG (invoked when a task misses its defined SLA)
+    """
+
+    task_on_success_callback: callable = attrs.field(default=None)
+    task_on_failure_callback: callable = attrs.field(default=None)
+    task_on_retry_callback: callable = attrs.field(default=None)
+    task_on_execute_callback: callable = attrs.field(default=None)
+
+    dag_on_failure_callback: callable = attrs.field(default=None)
+    dag_on_success_callback: callable = attrs.field(default=None)
+    dag_sla_miss_callback: callable = attrs.field(default=None)
+
+
+@attrs.define(frozen=True)
 class DependencyWaitPolicy:
     """
     Policy to build waits for models' dependencies.
@@ -201,6 +225,7 @@ class Config:
         turn off actual dbt runs and integrations with some external systems
     :param use_dbt_target_specific_pools: whether to use dbt target specific pools; if True, then airflow pools will be
         created for each dbt target with pattern `dbt_{target_name}`; if False, then only the default pool will be used
+    :param af_callbacks: config with callback functions for airflow DAGs and tasks
     :param mcd: config for mcd integration; must be installed as extra dependency
     :param k8s: settings for k8s operators
     """
@@ -219,6 +244,9 @@ class Config:
     dag_start_date: pendulum.datetime = attrs.field(default=pendulum.datetime(2023, 10, 1, 0, 0, 0, tz='UTC'))
     is_dev: bool = attrs.field(default=False)
     use_dbt_target_specific_pools: bool = attrs.field(default=True)
+
+    # airflow callbacks config
+    af_callbacks: Optional[AfCallbacksConfig] = attrs.field(default=None)
 
     # Monte Carlo Data integration
     mcd: Optional[MCDIntegrationConfig] = attrs.field(default=None)

--- a/dbt_af/dags.py
+++ b/dbt_af/dags.py
@@ -8,14 +8,14 @@ from airflow.models.param import Param
 from dbt_af.builder.dbt_af_builder import BackfillDomainDag, DbtAfGraph, get_domain_dag_start_date
 from dbt_af.common.constants import DBT_MODEL_DAG_PARAM, DEFAULT_DAG_ARGS
 from dbt_af.conf import Config
-from dbt_af.integrations.af_callbacks import prepare_callbacks
+from dbt_af.common.af_callbacks import af_custom_callbacks
 from dbt_af.operators.run import DbtRun
 
 
 def dbt_main_dags(graph: DbtAfGraph) -> dict[str, DAG]:
     af_dags = {}
 
-    dag_callbacks, task_callbacks = prepare_callbacks(graph.config)
+    dag_callbacks, task_callbacks = af_custom_callbacks(graph.config)
     domains = {node.domain_dag for node in graph.nodes}
 
     for domain_dag in domains:
@@ -57,7 +57,7 @@ def dbt_main_dags(graph: DbtAfGraph) -> dict[str, DAG]:
 def dbt_run_model_dag(config: Config) -> dict[str, DAG]:
     dag_name = 'dbt_run_model'
 
-    dag_callbacks, task_callbacks = prepare_callbacks(config)
+    dag_callbacks, task_callbacks = af_custom_callbacks(config)
     dag = DAG(
         dag_name,
         start_date=config.dag_start_date,

--- a/dbt_af/dags.py
+++ b/dbt_af/dags.py
@@ -8,14 +8,14 @@ from airflow.models.param import Param
 from dbt_af.builder.dbt_af_builder import BackfillDomainDag, DbtAfGraph, get_domain_dag_start_date
 from dbt_af.common.constants import DBT_MODEL_DAG_PARAM, DEFAULT_DAG_ARGS
 from dbt_af.conf import Config
-from dbt_af.integrations.mcd import prepare_mcd_callbacks
+from dbt_af.integrations.af_callbacks import prepare_callbacks
 from dbt_af.operators.run import DbtRun
 
 
 def dbt_main_dags(graph: DbtAfGraph) -> dict[str, DAG]:
     af_dags = {}
 
-    mcd_dag_callbacks, mcd_task_callbacks = prepare_mcd_callbacks(graph.config)
+    dag_callbacks, task_callbacks = prepare_callbacks(graph.config)
     domains = {node.domain_dag for node in graph.nodes}
 
     for domain_dag in domains:
@@ -29,7 +29,7 @@ def dbt_main_dags(graph: DbtAfGraph) -> dict[str, DAG]:
             max_active_runs=graph.config.max_active_dag_runs,
             render_template_as_native_obj=False,
             tags=['dbt'] + domain_dag.tags,
-            **mcd_dag_callbacks,
+            **dag_callbacks,
         )
         domain_dag.af_dag = dag
         af_dags[domain_dag.dag_name] = dag
@@ -41,7 +41,7 @@ def dbt_main_dags(graph: DbtAfGraph) -> dict[str, DAG]:
         node.domain_dag.af_dag = af_dags[node.domain_dag.dag_name]
 
     for node in graph.nodes:
-        node.add_af_callbacks(mcd_task_callbacks)
+        node.add_af_callbacks(task_callbacks)
         if node.af_component is None:
             node.init_af()
 
@@ -57,7 +57,7 @@ def dbt_main_dags(graph: DbtAfGraph) -> dict[str, DAG]:
 def dbt_run_model_dag(config: Config) -> dict[str, DAG]:
     dag_name = 'dbt_run_model'
 
-    mcd_dag_callbacks, mcd_task_callbacks = prepare_mcd_callbacks(config)
+    dag_callbacks, task_callbacks = prepare_callbacks(config)
     dag = DAG(
         dag_name,
         start_date=config.dag_start_date,
@@ -72,7 +72,7 @@ def dbt_run_model_dag(config: Config) -> dict[str, DAG]:
             'start_dttm': Param('2000-01-01T00:00:00', type='string'),
             'end_dttm': Param('2000-01-01T00:00:00', type='string'),
         },
-        **mcd_dag_callbacks,
+        **dag_callbacks,
     )
 
     target_environment = config.dbt_default_targets.default_target
@@ -82,7 +82,7 @@ def dbt_run_model_dag(config: Config) -> dict[str, DAG]:
         dag=dag,
         target_environment=target_environment,
         dbt_af_config=config,
-        **mcd_task_callbacks,
+        **task_callbacks,
     )
 
     return {dag_name: dag}

--- a/dbt_af/integrations/af_callbacks/__init__.py
+++ b/dbt_af/integrations/af_callbacks/__init__.py
@@ -1,5 +1,5 @@
-from .callbacks import prepare_callbacks  # noqa
+from .callbacks import prepare_custom_af_callbacks  # noqa
 
 __all__ = [
-    'prepare_callbacks',
+    'prepare_custom_af_callbacks',
 ]

--- a/dbt_af/integrations/af_callbacks/__init__.py
+++ b/dbt_af/integrations/af_callbacks/__init__.py
@@ -1,0 +1,5 @@
+from .callbacks import prepare_callbacks  # noqa
+
+__all__ = [
+    'prepare_callbacks',
+]

--- a/dbt_af/integrations/af_callbacks/callbacks.py
+++ b/dbt_af/integrations/af_callbacks/callbacks.py
@@ -1,23 +1,11 @@
 import logging
-from collections import defaultdict
-from typing import Callable, Dict, Tuple, Optional, List
 
 from dbt_af.conf import Config
-from dbt_af.integrations.mcd import prepare_mcd_callbacks
 
 
-def merge_dicts_by_key(*dicts: dict) -> Dict:
-    result_dict = defaultdict(list)
-
-    for d in dicts:
-        for key, value in d.items():
-            result_dict[key].append(value)
-    return dict(result_dict)
-
-
-def prepare_af_callbacks(config: Config) -> Tuple[Dict[str, Callable], Dict[str, Callable]]:
+def prepare_custom_af_callbacks(config: Config) -> tuple[dict[str, callable], dict[str, callable]]:
     if config.af_callbacks is None:
-        logging.warning('No callback defined')
+        logging.warning('No callback were passed')
         return {}, {}
 
     airflow_task_callbacks = {
@@ -34,13 +22,3 @@ def prepare_af_callbacks(config: Config) -> Tuple[Dict[str, Callable], Dict[str,
     }
 
     return airflow_dag_callbacks, airflow_task_callbacks
-
-
-def prepare_callbacks(config: Config) -> Tuple[Dict[str, List[Optional[Callable]]], Dict[str, List[Optional[Callable]]]]:
-    mcd_dag_callbacks, mcd_task_callbacks = prepare_mcd_callbacks(config)
-    airflow_dag_callbacks, airflow_task_callbacks = prepare_af_callbacks(config)
-
-    dag_callbacks = merge_dicts_by_key(mcd_dag_callbacks, airflow_dag_callbacks)
-    task_callbacks = merge_dicts_by_key(mcd_task_callbacks, airflow_task_callbacks)
-
-    return dict(dag_callbacks), dict(task_callbacks)

--- a/dbt_af/integrations/af_callbacks/callbacks.py
+++ b/dbt_af/integrations/af_callbacks/callbacks.py
@@ -1,0 +1,46 @@
+import logging
+from collections import defaultdict
+from typing import Callable, Dict, Tuple, Optional, List
+
+from dbt_af.conf import Config
+from dbt_af.integrations.mcd import prepare_mcd_callbacks
+
+
+def merge_dicts_by_key(*dicts: dict) -> Dict:
+    result_dict = defaultdict(list)
+
+    for d in dicts:
+        for key, value in d.items():
+            result_dict[key].append(value)
+    return dict(result_dict)
+
+
+def prepare_af_callbacks(config: Config) -> Tuple[Dict[str, Callable], Dict[str, Callable]]:
+    if config.af_callbacks is None:
+        logging.warning('No callback defined')
+        return {}, {}
+
+    airflow_task_callbacks = {
+        'on_success_callback': config.af_callbacks.task_on_success_callback,
+        'on_failure_callback': config.af_callbacks.task_on_failure_callback,
+        'on_retry_callback': config.af_callbacks.task_on_retry_callback,
+        'on_execute_callback': config.af_callbacks.task_on_execute_callback
+    }
+
+    airflow_dag_callbacks = {
+        'on_failure_callback': config.af_callbacks.dag_on_failure_callback,
+        'on_success_callback': config.af_callbacks.dag_on_success_callback,
+        'sla_miss_callback': config.af_callbacks.dag_sla_miss_callback,
+    }
+
+    return airflow_dag_callbacks, airflow_task_callbacks
+
+
+def prepare_callbacks(config: Config) -> Tuple[Dict[str, List[Optional[Callable]]], Dict[str, List[Optional[Callable]]]]:
+    mcd_dag_callbacks, mcd_task_callbacks = prepare_mcd_callbacks(config)
+    airflow_dag_callbacks, airflow_task_callbacks = prepare_af_callbacks(config)
+
+    dag_callbacks = merge_dicts_by_key(mcd_dag_callbacks, airflow_dag_callbacks)
+    task_callbacks = merge_dicts_by_key(mcd_task_callbacks, airflow_task_callbacks)
+
+    return dict(dag_callbacks), dict(task_callbacks)

--- a/dbt_af/operators/base.py
+++ b/dbt_af/operators/base.py
@@ -25,7 +25,7 @@ def get_delay_by_schedule(schedule_tag):
     return {'execution_timeout': timedelta(hours=6)}
 
 
-class DdtBaseOperator(BashOperator):
+class DbtBaseOperator(BashOperator):
     retries: int = 1
 
     @property
@@ -108,7 +108,7 @@ class DdtBaseOperator(BashOperator):
                         raise e
 
 
-class DbtConstOperator(DdtBaseOperator):
+class DbtConstOperator(DbtBaseOperator):
     def __init__(self, pool: str = DBT_COMPILE_POOL, **kwargs) -> None:
         task_id = f'dbt_{self.cli_command.replace(" ", "_")}'
         super().__init__(pool=pool, task_id=task_id, **kwargs)
@@ -184,7 +184,7 @@ class DbtModelVars(pydantic.BaseModel):
         return dict(**super().dict(**kwargs), **self.extra)
 
 
-class DbtIntervalActionOperator(DdtBaseOperator):
+class DbtIntervalActionOperator(DbtBaseOperator):
     overlap = False
 
     def execute(self, context):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-af"
-version = "0.5.3"
+version = "0.6.0"
 description = "Distibuted dbt runs on Apache Airflow"
 authors = [
     "Nikita Yurasov <nikitayurasov@toloka.ai>",

--- a/tests/airflow_dags/conftest.py
+++ b/tests/airflow_dags/conftest.py
@@ -261,7 +261,7 @@ def mock_mcd_callbacks(mocker):
     import dbt_af.dags as module_in_use
 
     mocker.patch(
-        f'{module_in_use.__name__}.{module_in_use.prepare_mcd_callbacks.__name__}',
+        f'{module_in_use.__name__}.{module_in_use.prepare_callbacks.__name__}',
         return_value=(dict(), dict()),
     )
 

--- a/tests/airflow_dags/conftest.py
+++ b/tests/airflow_dags/conftest.py
@@ -261,7 +261,7 @@ def mock_mcd_callbacks(mocker):
     import dbt_af.dags as module_in_use
 
     mocker.patch(
-        f'{module_in_use.__name__}.{module_in_use.prepare_callbacks.__name__}',
+        f'{module_in_use.__name__}.{module_in_use.af_custom_callbacks.__name__}',
         return_value=(dict(), dict()),
     )
 


### PR DESCRIPTION
This change adds the ability to use [callback functions in](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/callbacks.html) Airflow:

- AfCallbacksConfig configuration has been added to the config for assigning Airflow callback functions.
- prepare_callbacks() function has been created to enable the [combine](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/callbacks.html#:~:text=As%20of%20Airflow,on_failure_callback%3D%5Bcallback_func_1%2C%20callback_func_2%5D) of custom callback functions with functions from the MonteCarloData integration.

_I hereby agree to the terms of either individual CLA available at: https://toloka.ai/legal/cla_individual or corporate CLA available at: https://toloka.ai/legal/cla_corporate, whichever is applicable to me, as it pertains to direct contributions to dbt-af only._