### PR TITLE
MCD: use gateway connection ID for dbt artifact upload

### DIFF
--- a/dbt_af/__init__.py
+++ b/dbt_af/__init__.py
@@ -3,6 +3,6 @@ __all__ = [
     'conf',
 ]
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 
 from . import conf, dags  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-af"
-version = "0.7.0"
+version = "0.7.1"
 description = "Distibuted dbt runs on Apache Airflow"
 authors = [
     "Nikita Yurasov <nikitayurasov@toloka.ai>",


### PR DESCRIPTION
Use the `mcd-gateway-default-session` connection ID as recommended by default while uploading dbt artifacts. If this connection is unavailable, the old `mcd_default_session` connection ID will be used