### PR TITLE
Config: retry policies

### DIFF
--- a/dbt_af/conf/__init__.py
+++ b/dbt_af/conf/__init__.py
@@ -5,6 +5,8 @@ from dbt_af.conf.config import (
     DbtProjectConfig,
     K8sConfig,
     MCDIntegrationConfig,
+    RetriesConfig,
+    RetryPolicy,
     TableauIntegrationConfig,
 )
 
@@ -16,4 +18,6 @@ __all__ = [
     'MCDIntegrationConfig',
     'TableauIntegrationConfig',
     'CustomAfCallbacksConfig',
+    'RetriesConfig',
+    'RetryPolicy',
 ]

--- a/dbt_af/operators/base.py
+++ b/dbt_af/operators/base.py
@@ -26,9 +26,6 @@ def get_delay_by_schedule(schedule_tag):
 
 
 class DbtBaseOperator(BashOperator):
-    retries: int = 1
-    retry_policy: Optional[RetryPolicy] = None
-
     @property
     def cli_command(self) -> str:
         raise NotImplementedError()
@@ -53,6 +50,7 @@ class DbtBaseOperator(BashOperator):
         max_active_tis_per_dag: int = 1,  # only one parallel tasks in the universe
         debug_flg: bool = True,
         pool: Optional[str] = None,
+        retry_policy: Optional[RetryPolicy] = None,
         **kwargs,
     ) -> None:
         self.debug = '--debug' if debug_flg else ''
@@ -67,9 +65,7 @@ class DbtBaseOperator(BashOperator):
         af_pool = pool or f'dbt_{self.target_environment}' if dbt_af_config.use_dbt_target_specific_pools else None
 
         retry_policy = (
-            self.retry_policy.as_dict()
-            if self.retry_policy is not None
-            else dbt_af_config.retries_config.default_retry_policy
+            retry_policy.as_dict() if retry_policy is not None else dbt_af_config.retries_config.default_retry_policy
         )
         super().__init__(
             max_active_tis_per_dag=max_active_tis_per_dag,

--- a/dbt_af/operators/kubernetes_pod.py
+++ b/dbt_af/operators/kubernetes_pod.py
@@ -1,5 +1,4 @@
 import base64
-import datetime
 import json
 import logging
 import os
@@ -40,8 +39,6 @@ class DbtKubernetesPodOperator(KubernetesPodOperator):
 
         super().__init__(
             *args,
-            retries=self.retries,
-            retry_delay=datetime.timedelta(minutes=5),
             max_active_tis_per_dag=1,
             cmds=['bash', '-c', ' && '.join(self._prepare_docker_cmds())],
             in_cluster=True,
@@ -50,6 +47,7 @@ class DbtKubernetesPodOperator(KubernetesPodOperator):
             do_xcom_push=True,
             startup_timeout_seconds=1200,
             namespace=conf.get('kubernetes_executor', 'NAMESPACE'),
+            **dbt_af_config.retries_config.k8s_task_retry_policy.as_dict(),
             **kwargs,
         )
 

--- a/dbt_af/operators/kubernetes_pod.py
+++ b/dbt_af/operators/kubernetes_pod.py
@@ -21,8 +21,6 @@ PYTHON_SCRIPT_FILE = 'script.py'
 
 
 class DbtKubernetesPodOperator(KubernetesPodOperator):
-    retries = 2
-
     def __init__(
         self,
         dbt_model_name: str,

--- a/dbt_af/operators/macros.py
+++ b/dbt_af/operators/macros.py
@@ -10,13 +10,15 @@ from dbt_af.parser.dbt_node_model import DbtAFMaintenanceConfig, DbtModelMainten
 
 
 class DbtRunMacroOperation(DbtIntervalActionOperator):
-    retries = 2
-
     def __init__(self, dbt_af_config: Config, **kwargs):
         self.macro = self.macro_name
-        self.retry_policy = dbt_af_config.retries_config.macros_retry_policy
 
-        super().__init__(task_id=self.af_task_name, dbt_af_config=dbt_af_config, **kwargs)
+        super().__init__(
+            task_id=self.af_task_name,
+            dbt_af_config=dbt_af_config,
+            retry_policy=dbt_af_config.retries_config.macros_retry_policy,
+            **kwargs,
+        )
 
     @property
     def af_task_name(self) -> str:

--- a/dbt_af/operators/macros.py
+++ b/dbt_af/operators/macros.py
@@ -10,10 +10,13 @@ from dbt_af.parser.dbt_node_model import DbtAFMaintenanceConfig, DbtModelMainten
 
 
 class DbtRunMacroOperation(DbtIntervalActionOperator):
-    def __init__(self, **kwargs):
-        self.macro = self.macro_name
+    retries = 2
 
-        super().__init__(task_id=self.af_task_name, **kwargs)
+    def __init__(self, dbt_af_config: Config, **kwargs):
+        self.macro = self.macro_name
+        self.retry_policy = dbt_af_config.retries_config.macros_retry_policy
+
+        super().__init__(task_id=self.af_task_name, dbt_af_config=dbt_af_config, **kwargs)
 
     @property
     def af_task_name(self) -> str:

--- a/dbt_af/operators/run.py
+++ b/dbt_af/operators/run.py
@@ -39,54 +39,55 @@ class DbtBaseDatasetOperator(DbtBaseActionOperator):
 
 
 class DbtRun(DbtBaseDatasetOperator):
-    retries = 2
-
     @property
     def cli_command(self) -> str:
         return 'run'
 
     def __init__(self, dbt_af_config: 'Config', **kwargs) -> None:
-        self.retry_policy = dbt_af_config.retries_config.dbt_run_retry_policy
-        super().__init__(dbt_af_config=dbt_af_config, **kwargs)
+        super().__init__(
+            dbt_af_config=dbt_af_config,
+            retry_policy=dbt_af_config.retries_config.dbt_run_retry_policy,
+            **kwargs,
+        )
 
 
 class DbtSeed(DbtBaseDatasetOperator):
-    retries = 1
-
     @property
     def cli_command(self) -> str:
         return 'seed'
 
     def __init__(self, dbt_af_config: 'Config', **kwargs) -> None:
-        self.retry_policy = dbt_af_config.retries_config.dbt_seed_retry_policy
-        super().__init__(dbt_af_config=dbt_af_config, **kwargs)
+        super().__init__(
+            dbt_af_config=dbt_af_config,
+            retry_policy=dbt_af_config.retries_config.dbt_seed_retry_policy,
+            **kwargs,
+        )
 
 
 class DbtSnapshot(DbtBaseDatasetOperator):
-    retries = 1
-
     @property
     def cli_command(self) -> str:
         return 'snapshot'
 
     def __init__(self, dbt_af_config: 'Config', **kwargs) -> None:
-        self.retry_policy = dbt_af_config.retries_config.dbt_snapshot_retry_policy
-        super().__init__(dbt_af_config=dbt_af_config, **kwargs)
+        super().__init__(
+            dbt_af_config=dbt_af_config,
+            retry_policy=dbt_af_config.retries_config.dbt_snapshot_retry_policy,
+            **kwargs,
+        )
 
 
 class DbtTest(DbtBaseActionOperator):
-    retries = 1
-
     @property
     def cli_command(self) -> str:
         return 'test'
 
     def __init__(self, dbt_af_config: 'Config', **kwargs) -> None:
-        self.retry_policy = dbt_af_config.retries_config.dbt_test_retry_policy
         super().__init__(
             dbt_af_config=dbt_af_config,
             max_active_tis_per_dag=None,
             target_environment=dbt_af_config.dbt_default_targets.default_for_tests_target,
+            retry_policy=dbt_af_config.retries_config.dbt_test_retry_policy,
             overlap=True,
             **kwargs,
         )

--- a/dbt_af/operators/run.py
+++ b/dbt_af/operators/run.py
@@ -10,14 +10,6 @@ if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
-class DbtSelectRun(DbtBaseActionOperator):
-    retries: int = 1
-
-    @property
-    def cli_command(self) -> str:
-        return 'run'
-
-
 class DbtBaseDatasetOperator(DbtBaseActionOperator):
     def __init__(self, model_name: Optional[str], is_dataset_enable=False, model_type: str = 'sql', **kwargs) -> None:
         if model_name:
@@ -53,6 +45,10 @@ class DbtRun(DbtBaseDatasetOperator):
     def cli_command(self) -> str:
         return 'run'
 
+    def __init__(self, dbt_af_config: 'Config', **kwargs) -> None:
+        self.retry_policy = dbt_af_config.retries_config.dbt_run_retry_policy
+        super().__init__(dbt_af_config=dbt_af_config, **kwargs)
+
 
 class DbtSeed(DbtBaseDatasetOperator):
     retries = 1
@@ -62,6 +58,7 @@ class DbtSeed(DbtBaseDatasetOperator):
         return 'seed'
 
     def __init__(self, dbt_af_config: 'Config', **kwargs) -> None:
+        self.retry_policy = dbt_af_config.retries_config.dbt_seed_retry_policy
         super().__init__(dbt_af_config=dbt_af_config, **kwargs)
 
 
@@ -72,6 +69,10 @@ class DbtSnapshot(DbtBaseDatasetOperator):
     def cli_command(self) -> str:
         return 'snapshot'
 
+    def __init__(self, dbt_af_config: 'Config', **kwargs) -> None:
+        self.retry_policy = dbt_af_config.retries_config.dbt_snapshot_retry_policy
+        super().__init__(dbt_af_config=dbt_af_config, **kwargs)
+
 
 class DbtTest(DbtBaseActionOperator):
     retries = 1
@@ -81,6 +82,7 @@ class DbtTest(DbtBaseActionOperator):
         return 'test'
 
     def __init__(self, dbt_af_config: 'Config', **kwargs) -> None:
+        self.retry_policy = dbt_af_config.retries_config.dbt_test_retry_policy
         super().__init__(
             dbt_af_config=dbt_af_config,
             max_active_tis_per_dag=None,

--- a/dbt_af/operators/sensors.py
+++ b/dbt_af/operators/sensors.py
@@ -288,7 +288,6 @@ EXECUTION_DATE_FN = (
     .add(ScheduleTag.daily, ScheduleTag.monthly, partial(monthly_on_daily))
 )
 
-
 EXECUTION_DATE_DEEP_FN = (
     _TaskScheduleMapping(WaitPolicy.all)
     .add(ScheduleTag.hourly, ScheduleTag.daily, [partial(daily_on_hourly, n_hours=i) for i in range(24)])
@@ -356,6 +355,8 @@ class DbtExternalSensor(ExternalTaskSensor):
         dag: 'DAG',
         **kwargs,
     ) -> None:
+        retry_policy = dbt_af_config.retries_config.sensor_retry_policy.as_dict()
+        retry_policy['retries'] = max(_RETRIES_COUNT, kwargs.get('retries', 0), retry_policy['retries'])
         super().__init__(
             task_id=task_id,
             task_group=task_group,
@@ -366,13 +367,12 @@ class DbtExternalSensor(ExternalTaskSensor):
             max_active_tis_per_dag=None,
             pool=DBT_SENSOR_POOL if dbt_af_config.use_dbt_target_specific_pools else None,
             mode='reschedule',
-            retries=max(_RETRIES_COUNT, kwargs.get('retries', 0)),
             skipped_states=[State.NONE, State.SKIPPED],
             failed_states=[State.FAILED, State.UPSTREAM_FAILED],
             timeout=6 * 60 * 60,
             poke_interval=_POKE_INTERVALS_SECONDS.get(dep_schedule.name, _DEFAULT_POKE_INTERVAL_SECONDS),
-            retry_delay=datetime.timedelta(seconds=60 * 30),
             exponential_backoff=False,
+            **retry_policy,
             **kwargs,
         )
 
@@ -381,7 +381,7 @@ class DbtSourceFreshnessSensor(PythonSensor):
     """
     :param wait_timeout: maximum time (in seconds) to wait for the sensor to return True
     :param retries: number of retries that should be performed before failing the sensor.
-    :param poke_interval: time (in seconds) that the sensor should wait in between each tries
+    :param poke_interval: time (in seconds) that the sensor should wait in between each try
     """
 
     template_fields: Sequence[str] = ('templates_dict', 'op_args', 'op_kwargs', 'env')
@@ -396,7 +396,6 @@ class DbtSourceFreshnessSensor(PythonSensor):
         source_identifier: str,
         dbt_af_config: Config,
         target_environment: str = None,
-        wait_timeout: int = None,
         **kwargs,
     ):
         self.env = env
@@ -405,24 +404,18 @@ class DbtSourceFreshnessSensor(PythonSensor):
         self.target_environment = target_environment or dbt_af_config.dbt_default_targets.default_for_tests_target
         self.dbt_af_config = dbt_af_config
 
-        if kwargs.get('retries') and wait_timeout:
-            raise ValueError('You can not specify both wait_timeout and retries')
-        if not kwargs.get('retries') and not wait_timeout:
-            wait_timeout = _DEFAULT_WAIT_TIMEOUT
-
-        _poke_interval = kwargs.get('poke_interval', _DEFAULT_POKE_INTERVAL_SECONDS)
-        _retries = kwargs.get('retries', wait_timeout // _poke_interval - 1)
-        _airflow_task_timeout = max(_DEFAULT_WAIT_TIMEOUT, wait_timeout)
+        retry_policy = dbt_af_config.retries_config.dbt_source_freshness_retry_policy.as_dict()
+        retry_policy['retries'] = _DEFAULT_WAIT_TIMEOUT // _DEFAULT_POKE_INTERVAL_SECONDS - 1
+        retry_policy['poke_interval'] = _DEFAULT_POKE_INTERVAL_SECONDS
+        retry_policy['timeout'] = max(_DEFAULT_WAIT_TIMEOUT, _DEFAULT_WAIT_TIMEOUT)
 
         super().__init__(
             task_id=task_id,
             dag=dag,
             pool=DBT_SENSOR_POOL if dbt_af_config.use_dbt_target_specific_pools else None,
-            poke_interval=_poke_interval,
-            timeout=_airflow_task_timeout,
-            retries=_retries,
             mode='reschedule',
             python_callable=self._check_freshness,
+            **retry_policy,
             **kwargs,
         )
 

--- a/dbt_af/operators/supplemental.py
+++ b/dbt_af/operators/supplemental.py
@@ -30,5 +30,6 @@ class TableauExtractsRefreshOperator(PythonOperator):
                 'tableau_refresh_tasks': tableau_refresh_tasks,
                 'dbt_af_config': dbt_af_config,
             },
+            **dbt_af_config.retries_config.supplemental_task_retry_policy.as_dict(),
             **kwargs,
         )

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,12 @@
 1. Running instance of Airflow. There are a few ways to get this. The easiest is to use the Docker Compose to get a local instance running. See [docs](using_docker_compose.md) for more information.
 2. Install `dbt-af` if you are not using the Docker Compose method.
     - via pip: `pip install dbt-af[tests,examples]`
-3. Add `dbt_dev` and `dbt_sensor_pool` [pools](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/pools.html) to Airflow.
+3. Build dbt manifest. You can use the provided [script](./dags/build_manifest.sh) to build the manifest.
+```bash
+cd examples/dags
+./build_manifest.sh
+```
+4. Add `dbt_dev` and `dbt_sensor_pool` [pools](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/pools.html) to Airflow.
    
     - By using Airflow UI ![Airflow Pools](../docs/static/add_new_af_pool.png)
     - By using Airflow CLI: `airflow pools set dbt_dev 4 "dev"`

--- a/examples/advanced_project.md
+++ b/examples/advanced_project.md
@@ -8,6 +8,7 @@
 4. [Large tests](#large-tests)
 5. [Using different targets](#using-different-targets)
 6. [Explicit dbt target](#explicit-dbt-target)
+7. [Customizing retries](#customizing-retries)
 
 DAG file: [example_advanced_dbt_af_dag.py](dags/example_advanced_dbt_af_dag.py)
 
@@ -95,7 +96,9 @@ All DAGs with large tests have `@daily` scheduling.
 <img src="../docs/static/large_tests.png" alt="drawing" width="600"/>
 
 ## Using different targets
-Because of different payloads, it might be useful to use different targets for different models' and tests' types. Some of them require more resources, some of them are more time-consuming, and some of them are more important.
+
+Because of different payloads, it might be useful to use different targets for different models' and tests' types. Some
+of them require more resources, some of them are more time-consuming, and some of them are more important.
 
 With `dbt-af` it's required to set up four targets in `dbt_project.yml` file for all models and seeds:
 
@@ -112,7 +115,9 @@ seeds:
   py_cluster: "dev"
   bf_cluster: "dev"
 ```
+
 and to set up default targets in `dbt-af` config:
+
 ```python
 from dbt_af.conf import Config, DbtDefaultTargetsConfig
 
@@ -126,29 +131,68 @@ config = Config(
 )
 ```
 
-In this example, all models and seeds are going to be run at _dev_ target. But you can customize it for your needs for each domain and each layer.
+In this example, all models and seeds are going to be run at _dev_ target. But you can customize it for your needs for
+each domain and each layer.
 
 ### How is the target determined?
+
 There are a few rules to determine the target for the task:
+
 - If the node is _test_, then `config.dbt_default_targets.default_for_tests_target` target is used.
 - If the node is _model_:
-  - If there are no pre-hooks, it's _sql_ model, and scheduling is `@daily` or `@weekly`, then `daily_sql_cluster` target is used.
-  - Otherwise, `sql_cluster` target is used.
+    - If there are no pre-hooks, it's _sql_ model, and scheduling is `@daily` or `@weekly`, then `daily_sql_cluster`
+      target is used.
+    - Otherwise, `sql_cluster` target is used.
 - Otherwise, use `py_cluster` target.
 
 ## Explicit dbt target
-In rare cases, you might want to run a specific model at a specific target. You can do this by setting the `dbt_target` parameter in the model's config.
+
+In rare cases, you might want to run a specific model at a specific target. You can do this by setting the `dbt_target`
+parameter in the model's config.
 
 ```yaml
 config:
   dbt_target: large_dev
 ```
 
+## Customizing retries
+
+Since dbt-af is built from different DAG components (dbt tasks, sensors, etc.),
+you can customize retries for each component type.
+To do this, you can specify desired retry policies in the `dbt-af` config.
+
+By default, there's a default retry policy for all components,
+but you can override it for each component type individually:
+
+```python
+from datetime import timedelta
+from dbt_af.conf import Config, RetriesConfig, RetryPolicy
+
+config = Config(
+    # ...
+    retries_config=RetriesConfig(
+        default_retry_policy=RetryPolicy(
+            retries=1,
+            retry_delay=timedelta(minutes=5),
+            retry_exponential_backoff=True,
+            max_retry_delay=timedelta(minutes=30)
+        ),
+        dbt_run_retry_policy=RetryPolicy(retries=3),
+    )
+    # ...
+)
+```
+
+All unspecified policies or policies' parameters will fall back to the default retry policy.
+
 ## List of Examples
+
 1. [Basic Project](basic_project.md): a single domain, small tests, and a single target.
-3. [Dependencies management](dependencies_management.md): how to manage dependencies between models in different domains.
+3. [Dependencies management](dependencies_management.md): how to manage dependencies between models in different
+   domains.
 4. [Manual scheduling](manual_scheduling.md): domains with manual scheduling.
-5. [Maintenance and source freshness](maintenance_and_source_freshness.md): how to manage maintenance tasks and source freshness.
+5. [Maintenance and source freshness](maintenance_and_source_freshness.md): how to manage maintenance tasks and source
+   freshness.
 6. [Kubernetes tasks](kubernetes_tasks.md): how to run dbt models in Kubernetes.
 7. [Integration with other tools](integration_with_other_tools.md): how to integrate dbt-af with other tools.
 8. [\[Preview\] Extras and scripts](extras_and_scripts.md): available extras and scripts.

--- a/examples/dags/build_manifest.sh
+++ b/examples/dags/build_manifest.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source ../.env
 dbt clean --no-clean-project-files-only --project-dir . --profiles-dir . --target dev
 dbt deps --debug --project-dir . --profiles-dir . --target dev
 dbt parse --debug --project-dir . --profiles-dir . --target dev

--- a/examples/dags/build_manifest.sh
+++ b/examples/dags/build_manifest.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-source ../.env
-dbt clean --no-clean-project-files-only --project-dir . --profiles-dir . --target dev
-dbt deps --debug --project-dir . --profiles-dir . --target dev
-dbt parse --debug --project-dir . --profiles-dir . --target dev
+set -euoa pipefail
+
+REPO_DIR="$(git rev-parse --show-toplevel)"
+source "${REPO_DIR}/examples/.env"
+
+DBT_PROJECT_DIR="${REPO_DIR}/examples/dags"
+dbt clean --no-clean-project-files-only --project-dir "${DBT_PROJECT_DIR}" --profiles-dir "${DBT_PROJECT_DIR}" --target dev
+dbt deps --debug --project-dir "${DBT_PROJECT_DIR}" --profiles-dir "${DBT_PROJECT_DIR}" --target dev
+dbt parse --debug --project-dir "${DBT_PROJECT_DIR}" --profiles-dir "${DBT_PROJECT_DIR}" --target dev

--- a/examples/dags/example_advanced_dbt_af_dag.py
+++ b/examples/dags/example_advanced_dbt_af_dag.py
@@ -1,7 +1,9 @@
 # LABELS: dag, airflow (it's required for airflow dag-processor)
+from datetime import timedelta
+
 import pendulum
 
-from dbt_af.conf import Config, DbtDefaultTargetsConfig, DbtProjectConfig
+from dbt_af.conf import Config, DbtDefaultTargetsConfig, DbtProjectConfig, RetriesConfig, RetryPolicy
 from dbt_af.dags import compile_dbt_af_dags
 
 # specify here all settings for your dbt project
@@ -18,6 +20,14 @@ config = Config(
     dbt_default_targets=DbtDefaultTargetsConfig(default_target='dev', default_for_tests_target='tests'),
     dag_start_date=pendulum.yesterday(),
     is_dev=False,  # set to True if you want to turn on dry-run mode
+    retries_config=RetriesConfig(
+        default_retry_policy=RetryPolicy(retries=3, retry_delay=timedelta(minutes=5)),
+        dbt_run_retry_policy=RetryPolicy(retries=10, retry_delay=timedelta(minutes=1)),
+        dbt_test_retry_policy=RetryPolicy(retries=0),
+        sensor_retry_policy=RetryPolicy(retries=30, retry_delay=timedelta(minutes=30)),
+        k8s_task_retry_policy=RetryPolicy(retry_delay=timedelta(minutes=5)),
+        supplemental_task_retry_policy=RetryPolicy(retries=0),
+    ),
 )
 
 dags = compile_dbt_af_dags(

--- a/tests/test_retry_conf.py
+++ b/tests/test_retry_conf.py
@@ -1,0 +1,34 @@
+from datetime import timedelta
+
+import attrs
+import pytest
+
+from dbt_af.conf import RetriesConfig, RetryPolicy
+
+
+@pytest.fixture
+def non_standard_retry_policy():
+    return RetryPolicy(retries=5, retry_delay=timedelta(seconds=10))
+
+
+def test_default_retries_config():
+    default_retries_config = RetriesConfig()
+    for _attr in attrs.fields(RetriesConfig):
+        assert getattr(default_retries_config, _attr.name) == default_retries_config.default_retry_policy
+
+
+def test_retries_config_with_policy_overwrite(non_standard_retry_policy):
+    config = RetriesConfig(
+        default_retry_policy=RetryPolicy(retries=3, retry_delay=timedelta(seconds=5), retry_exponential_backoff=True),
+        sensor_retry_policy=RetryPolicy(retries=5, retry_delay=timedelta(seconds=10)),
+    )
+
+    assert config.sensor_retry_policy == RetryPolicy(
+        retries=5, retry_delay=timedelta(seconds=10), retry_exponential_backoff=True
+    )
+    assert config.dbt_run_retry_policy == RetryPolicy(
+        retries=3, retry_delay=timedelta(seconds=5), retry_exponential_backoff=True
+    )
+    assert config.supplemental_task_retry_policy == RetryPolicy(
+        retries=3, retry_delay=timedelta(seconds=5), retry_exponential_backoff=True
+    )


### PR DESCRIPTION
Add config to customize retry policies for different DAG components.

Example:
```python
from datetime import timedelta
from dbt_af.conf import Config, RetriesConfig, RetryPolicy

config = Config(
    # ...
    retries_config=RetriesConfig(
        default_retry_policy=RetryPolicy(
            retries=1,
            retry_delay=timedelta(minutes=5),
            retry_exponential_backoff=True,
            max_retry_delay=timedelta(minutes=30)
        ),
        dbt_run_retry_policy=RetryPolicy(retries=3),
    )
    # ...
)
```