### PR TITLE
release: v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.8.1
+Fixes:
+- upgrade `airflow-mcd` to 0.3.3 version to fix bug with DAG callbacks
+- fix correct usage of the default retry policy if none has been passed.
+
 ## v0.8.0
 Features:
 - remove `airflow.Dataset` from backfill DAGs

--- a/dbt_af/__init__.py
+++ b/dbt_af/__init__.py
@@ -4,6 +4,6 @@ __all__ = [
 ]
 
 # note that this version is maintained by the release manager - do not update it manually
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 
 from . import conf, dags  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dbt-af"
 # note that this version is maintained by the release manager - do not update it manually
-version = "0.8.0"
+version = "0.8.1"
 description = "Distibuted dbt runs on Apache Airflow"
 authors = [
     "Nikita Yurasov <nikitayurasov@toloka.ai>",


### PR DESCRIPTION
# v0.8.1
Fixes:
- upgrade `airflow-mcd` to 0.3.3 version to fix bug with DAG callbacks
- fix correct usage of the default retry policy if none has been passed.