### PR TITLE
fix: cron expressions comparison

### DIFF
--- a/dbt_af/common/scheduling.py
+++ b/dbt_af/common/scheduling.py
@@ -308,6 +308,10 @@ class ScheduleTag(Enum):
         return self.value.name
 
     @property
+    def level(self):
+        return self.value.level
+
+    @property
     def default_cron_expression(self):
         return self.value.default_cron_expression
 

--- a/tests/test_scheduling_tags.py
+++ b/tests/test_scheduling_tags.py
@@ -3,6 +3,7 @@ import datetime
 import pytest
 
 from dbt_af.common.scheduling import (
+    ScheduleTag,
     _DailyScheduleTag,
     _HourlyScheduleTag,
     _ManualScheduleTag,
@@ -115,3 +116,19 @@ def test_monthly_schedule_tag():
     for shift in bad_timeshifts:
         with pytest.raises(ValueError):
             _MonthlyScheduleTag(shift).af_repr()
+
+
+def test_scheduling_tag_levels_all_unique():
+    all_levels = [tag().level for tag in ScheduleTag]
+    assert len(all_levels) == len(set(all_levels))
+
+
+def test_scheduling_tag_correct_comparison():
+    assert (
+        ScheduleTag.manual()
+        < ScheduleTag.every15minutes()
+        < ScheduleTag.hourly()
+        < ScheduleTag.daily()
+        < ScheduleTag.weekly()
+        < ScheduleTag.monthly()
+    )

--- a/tests/test_sensors_wait_fns.py
+++ b/tests/test_sensors_wait_fns.py
@@ -1,51 +1,56 @@
-import datetime
+from datetime import datetime, timedelta
 
 import pytest
 from dateutil.relativedelta import relativedelta
 
-from dbt_af.common.scheduling import _DailyScheduleTag, _HourlyScheduleTag, _MonthlyScheduleTag, _WeeklyScheduleTag
-from dbt_af.operators.sensors import AfExecutionDateFn, CronExpression, calculate_task_to_wait_execution_date
+from dbt_af.common.scheduling import (
+    _DailyScheduleTag,
+    _HourlyScheduleTag,
+    _MonthlyScheduleTag,
+    _WeeklyScheduleTag,
+)
+from dbt_af.operators.sensors import AfExecutionDateFn, calculate_task_to_wait_execution_date
 from dbt_af.parser.dbt_node_model import WaitPolicy
 
 
 @pytest.fixture
 def execution_date_during_the_day():
-    return datetime.datetime(2023, 10, 12, 16, 0, 0)
+    return datetime(2023, 10, 12, 16, 0, 0)
 
 
 @pytest.fixture
 def execution_date_during_the_night():
-    return datetime.datetime(2023, 10, 12, 0, 0, 0)
+    return datetime(2023, 10, 12, 0, 0, 0)
 
 
 def test_daily_on_hourly(execution_date_during_the_day, execution_date_during_the_night):
     assert calculate_task_to_wait_execution_date(
         execution_date_during_the_day,
-        self_cron=CronExpression('0 16 * * *'),
-        upstream_cron=_HourlyScheduleTag.default_cron_expression,
-    ) == execution_date_during_the_day + datetime.timedelta(hours=23)
+        self_schedule=_DailyScheduleTag(timedelta(hours=16)),
+        upstream_schedule=_HourlyScheduleTag(),
+    ) == execution_date_during_the_day + timedelta(hours=23)
     assert calculate_task_to_wait_execution_date(
         execution_date_during_the_night,
-        self_cron=_DailyScheduleTag.default_cron_expression,
-        upstream_cron=_HourlyScheduleTag.default_cron_expression,
-    ) == execution_date_during_the_night + datetime.timedelta(hours=23)
+        self_schedule=_DailyScheduleTag(),
+        upstream_schedule=_HourlyScheduleTag(),
+    ) == execution_date_during_the_night + timedelta(hours=23)
 
     for i in range(24):
         assert calculate_task_to_wait_execution_date(
             execution_date_during_the_day,
-            self_cron=CronExpression('0 16 * * *'),
-            upstream_cron=_HourlyScheduleTag.default_cron_expression,
+            self_schedule=_DailyScheduleTag(timedelta(hours=16)),
+            upstream_schedule=_HourlyScheduleTag(),
             num_iter=i,
-        ) == execution_date_during_the_day + datetime.timedelta(hours=i)
+        ) == execution_date_during_the_day + timedelta(hours=i)
         assert calculate_task_to_wait_execution_date(
             execution_date_during_the_night,
-            self_cron=_DailyScheduleTag.default_cron_expression,
-            upstream_cron=_HourlyScheduleTag.default_cron_expression,
+            self_schedule=_DailyScheduleTag(),
+            upstream_schedule=_HourlyScheduleTag(),
             num_iter=i,
-        ) == execution_date_during_the_night + datetime.timedelta(hours=i)
+        ) == execution_date_during_the_night + timedelta(hours=i)
 
-    daily_shift = datetime.timedelta(hours=3, minutes=7)
-    hourly_shift = datetime.timedelta(minutes=11)
+    daily_shift = timedelta(hours=3, minutes=7)
+    hourly_shift = timedelta(minutes=11)
     fn_set_last = AfExecutionDateFn(
         upstream_schedule_tag=_HourlyScheduleTag(hourly_shift),
         downstream_schedule_tag=_DailyScheduleTag(daily_shift),
@@ -54,7 +59,7 @@ def test_daily_on_hourly(execution_date_during_the_day, execution_date_during_th
     assert len(fn_set_last) == 1
     assert fn_set_last[0](
         execution_date_during_the_night.replace(hour=3, minute=7)
-    ) == execution_date_during_the_night.replace(hour=3, minute=0) + datetime.timedelta(hours=23, minutes=11)
+    ) == execution_date_during_the_night.replace(hour=3, minute=0) + timedelta(hours=23, minutes=11)
 
     fn_set_all = AfExecutionDateFn(
         upstream_schedule_tag=_HourlyScheduleTag(hourly_shift),
@@ -65,34 +70,34 @@ def test_daily_on_hourly(execution_date_during_the_day, execution_date_during_th
     for i in range(24):
         assert fn_set_all[i](
             execution_date_during_the_night.replace(hour=3, minute=7)
-        ) == execution_date_during_the_night.replace(hour=3, minute=0) + datetime.timedelta(hours=i, minutes=11)
+        ) == execution_date_during_the_night.replace(hour=3, minute=0) + timedelta(hours=i, minutes=11)
 
 
 def test_hourly_on_daily(execution_date_during_the_day, execution_date_during_the_night):
     assert calculate_task_to_wait_execution_date(
         execution_date_during_the_day,
-        self_cron=CronExpression('0 * * * *'),
-        upstream_cron=_DailyScheduleTag.default_cron_expression,
-    ) == datetime.datetime(2023, 10, 11, 0, 0, 0)
+        self_schedule=_HourlyScheduleTag(),
+        upstream_schedule=_DailyScheduleTag(),
+    ) == datetime(2023, 10, 11, 0, 0, 0)
     assert calculate_task_to_wait_execution_date(
         execution_date_during_the_night,
-        self_cron=CronExpression('0 * * * *'),
-        upstream_cron=_DailyScheduleTag.default_cron_expression,
-    ) == datetime.datetime(2023, 10, 11, 0, 0, 0)
+        self_schedule=_HourlyScheduleTag(),
+        upstream_schedule=_DailyScheduleTag(),
+    ) == datetime(2023, 10, 11, 0, 0, 0)
 
     assert calculate_task_to_wait_execution_date(
         execution_date_during_the_day.replace(hour=9),
-        self_cron=_HourlyScheduleTag(datetime.timedelta(minutes=20)).cron_expression(),
-        upstream_cron=_DailyScheduleTag.default_cron_expression,
-    ) == datetime.datetime(2023, 10, 11, 0, 0, 0)
+        self_schedule=_HourlyScheduleTag(timedelta(minutes=20)),
+        upstream_schedule=_DailyScheduleTag(),
+    ) == datetime(2023, 10, 11, 0, 0, 0)
     assert calculate_task_to_wait_execution_date(
         execution_date_during_the_night.replace(hour=7),
-        self_cron=_HourlyScheduleTag(datetime.timedelta(minutes=30)).cron_expression(),
-        upstream_cron=_DailyScheduleTag(datetime.timedelta(hours=3)).cron_expression(),
-    ) == datetime.datetime(2023, 10, 11, 3, 0, 0)
+        self_schedule=_HourlyScheduleTag(timedelta(minutes=30)),
+        upstream_schedule=_DailyScheduleTag(timedelta(hours=3)),
+    ) == datetime(2023, 10, 11, 3, 0, 0)
 
-    daily_shift = datetime.timedelta(hours=3, minutes=7)
-    hourly_shift = datetime.timedelta(minutes=11)
+    daily_shift = timedelta(hours=3, minutes=7)
+    hourly_shift = timedelta(minutes=11)
     fn_set_last = AfExecutionDateFn(
         upstream_schedule_tag=_DailyScheduleTag(daily_shift),
         downstream_schedule_tag=_HourlyScheduleTag(hourly_shift),
@@ -101,7 +106,7 @@ def test_hourly_on_daily(execution_date_during_the_day, execution_date_during_th
     assert len(fn_set_last) == 1
     assert fn_set_last[0](
         execution_date_during_the_night.replace(minute=11)
-    ) == execution_date_during_the_night.replace(hour=3, minute=7) - datetime.timedelta(days=2)
+    ) == execution_date_during_the_night.replace(hour=3, minute=7) - timedelta(days=2)
 
     fn_set_all = AfExecutionDateFn(
         upstream_schedule_tag=_DailyScheduleTag(daily_shift),
@@ -111,7 +116,7 @@ def test_hourly_on_daily(execution_date_during_the_day, execution_date_during_th
     assert len(fn_set_all) == 1
     assert fn_set_all[0](execution_date_during_the_night.replace(minute=11)) == execution_date_during_the_night.replace(
         hour=3, minute=7
-    ) - datetime.timedelta(days=2)
+    ) - timedelta(days=2)
 
 
 def test_weekly_on_hourly(execution_date_during_the_day, execution_date_during_the_night):
@@ -121,12 +126,12 @@ def test_weekly_on_hourly(execution_date_during_the_day, execution_date_during_t
         wait_policy=WaitPolicy.last,
     ).get_execution_dates()
     assert len(fn_set_last) == 1
-    assert fn_set_last[0](execution_date_during_the_night) == execution_date_during_the_night + datetime.timedelta(
+    assert fn_set_last[0](execution_date_during_the_night) == execution_date_during_the_night + timedelta(
         days=3
-    ) - datetime.timedelta(hours=1)
+    ) - timedelta(hours=1)
 
-    hourly_shift = datetime.timedelta(minutes=11)
-    weekly_shift = datetime.timedelta(days=3, hours=7)
+    hourly_shift = timedelta(minutes=11)
+    weekly_shift = timedelta(days=3, hours=7)
     fn_set_all = AfExecutionDateFn(
         upstream_schedule_tag=_HourlyScheduleTag(hourly_shift),
         downstream_schedule_tag=_WeeklyScheduleTag(weekly_shift),
@@ -139,19 +144,19 @@ def test_weekly_on_daily(execution_date_during_the_day, execution_date_during_th
     execution_date_during_the_night = execution_date_during_the_night.replace(day=15)  # end of the week
     assert calculate_task_to_wait_execution_date(
         execution_date_during_the_night,
-        self_cron=_WeeklyScheduleTag.default_cron_expression,
-        upstream_cron=_DailyScheduleTag.default_cron_expression,
-    ) == datetime.datetime(2023, 10, 21)  # 15 + 7 - 1
+        self_schedule=_WeeklyScheduleTag(),
+        upstream_schedule=_DailyScheduleTag(),
+    ) == datetime(2023, 10, 21)  # 15 + 7 - 1
 
-    daily_shift = datetime.timedelta(hours=3, minutes=7)
-    weekly_shift = datetime.timedelta(days=6, hours=23)
+    daily_shift = timedelta(hours=3, minutes=7)
+    weekly_shift = timedelta(days=6, hours=23)
     fn_set_last = AfExecutionDateFn(
         upstream_schedule_tag=_DailyScheduleTag(daily_shift),
         downstream_schedule_tag=_WeeklyScheduleTag(weekly_shift),
         wait_policy=WaitPolicy.last,
     ).get_execution_dates()
     assert len(fn_set_last) == 1
-    assert fn_set_last[0](execution_date_during_the_night.replace(hour=23)) == datetime.datetime(2023, 10, 21, 3, 7, 0)
+    assert fn_set_last[0](execution_date_during_the_night.replace(hour=23)) == datetime(2023, 10, 21, 3, 7, 0)
 
     fn_set_all = AfExecutionDateFn(
         upstream_schedule_tag=_DailyScheduleTag(daily_shift),
@@ -160,19 +165,19 @@ def test_weekly_on_daily(execution_date_during_the_day, execution_date_during_th
     ).get_execution_dates()
     assert len(fn_set_all) == 7
     for i in range(7):
-        assert fn_set_all[i](execution_date_during_the_night.replace(day=14, hour=23)) == datetime.datetime(
+        assert fn_set_all[i](execution_date_during_the_night.replace(day=14, hour=23)) == datetime(
             2023, 10, 15, 3, 7, 0
-        ) + datetime.timedelta(days=i)
+        ) + timedelta(days=i)
 
 
 def test_daily_on_weekly(execution_date_during_the_day, execution_date_during_the_night):
     # [2023-10-12T05:15:00, 2023-10-13T05:15:00] will wait weekly task with cron expression: 45 7 * * 4 at
     # data interval [2023-10-05T07:45:00, 2023-10-12T07:45:00]
     assert calculate_task_to_wait_execution_date(
-        datetime.datetime(2023, 10, 12, 5, 15, 0),
-        self_cron=CronExpression('15 5 * * *'),
-        upstream_cron=CronExpression('45 7 * * 4'),
-    ) == datetime.datetime(2023, 10, 5, 7, 45, 0)
+        datetime(2023, 10, 12, 5, 15, 0),
+        self_schedule=_DailyScheduleTag(timedelta(hours=5, minutes=15)),
+        upstream_schedule=_WeeklyScheduleTag(timedelta(hours=7, minutes=45, days=4)),
+    ) == datetime(2023, 10, 5, 7, 45, 0)
 
     fn_set_last = AfExecutionDateFn(
         upstream_schedule_tag=_WeeklyScheduleTag(),
@@ -180,13 +185,11 @@ def test_daily_on_weekly(execution_date_during_the_day, execution_date_during_th
         wait_policy=WaitPolicy.last,
     ).get_execution_dates()
     assert len(fn_set_last) == 1
-    assert fn_set_last[0](execution_date_during_the_night) == datetime.datetime(2023, 10, 1, 0, 0, 0)
-    assert fn_set_last[0](execution_date_during_the_night + datetime.timedelta(days=3)) == datetime.datetime(
-        2023, 10, 8, 0, 0, 0
-    )
-    assert fn_set_last[0](execution_date_during_the_night + datetime.timedelta(days=6)) == datetime.datetime(
+    assert fn_set_last[0](execution_date_during_the_night) == datetime(2023, 10, 1, 0, 0, 0)
+    assert fn_set_last[0](execution_date_during_the_night + timedelta(days=3)) == datetime(2023, 10, 8, 0, 0, 0)
+    assert fn_set_last[0](execution_date_during_the_night + timedelta(days=6)) == datetime(
         2023, 10, 1, 0, 0, 0
-    ) + datetime.timedelta(days=7)
+    ) + timedelta(days=7)
 
     fn_set_all = AfExecutionDateFn(
         upstream_schedule_tag=_WeeklyScheduleTag(),
@@ -194,75 +197,69 @@ def test_daily_on_weekly(execution_date_during_the_day, execution_date_during_th
         wait_policy=WaitPolicy.all,
     ).get_execution_dates()
     assert len(fn_set_all) == 1
-    assert fn_set_all[0](execution_date_during_the_night) == datetime.datetime(2023, 10, 1, 0, 0, 0)
-    assert fn_set_last[0](execution_date_during_the_night + datetime.timedelta(days=6)) == datetime.datetime(
+    assert fn_set_all[0](execution_date_during_the_night) == datetime(2023, 10, 1, 0, 0, 0)
+    assert fn_set_last[0](execution_date_during_the_night + timedelta(days=6)) == datetime(
         2023, 10, 1, 0, 0, 0
-    ) + datetime.timedelta(days=7)
+    ) + timedelta(days=7)
 
 
 def test_hourly_on_weekly(execution_date_during_the_day, execution_date_during_the_night):
     # [2023-10-10T05:15:00, 2023-10-10T06:15:00] will wait weekly task with cron expression: 45 7 * * 4 at
     # data interval [2023-10-05T07:45:00, 2023-10-12T07:45:00]
     assert calculate_task_to_wait_execution_date(
-        datetime.datetime(2023, 10, 10, 5, 15, 0),
-        self_cron=CronExpression('15 * * * *'),
-        upstream_cron=CronExpression('45 7 * * 4'),
-    ) == datetime.datetime(2023, 9, 28, 7, 45, 0)
+        datetime(2023, 10, 10, 5, 15, 0),
+        self_schedule=_HourlyScheduleTag(timedelta(minutes=15)),
+        upstream_schedule=_WeeklyScheduleTag(timedelta(hours=7, minutes=45, days=4)),
+    ) == datetime(2023, 9, 28, 7, 45, 0)
     fn_set_last = AfExecutionDateFn(
         upstream_schedule_tag=_WeeklyScheduleTag(),
         downstream_schedule_tag=_HourlyScheduleTag(),
         wait_policy=WaitPolicy.last,
     ).get_execution_dates()
     assert len(fn_set_last) == 1
-    assert fn_set_last[0](execution_date_during_the_night) == datetime.datetime(2023, 10, 1, 0, 0, 0)
-    assert fn_set_last[0](execution_date_during_the_night + datetime.timedelta(days=3)) == datetime.datetime(
-        2023, 10, 8, 0, 0, 0
-    )
-    assert fn_set_last[0](execution_date_during_the_night + datetime.timedelta(days=6)) == datetime.datetime(
+    assert fn_set_last[0](execution_date_during_the_night) == datetime(2023, 10, 1, 0, 0, 0)
+    assert fn_set_last[0](execution_date_during_the_night + timedelta(days=3)) == datetime(2023, 10, 8, 0, 0, 0)
+    assert fn_set_last[0](execution_date_during_the_night + timedelta(days=6)) == datetime(
         2023, 10, 1, 0, 0, 0
-    ) + datetime.timedelta(days=7)
+    ) + timedelta(days=7)
 
-    weekly_shift = datetime.timedelta(days=3, hours=7)
-    hourly_shift = datetime.timedelta(minutes=11)
+    weekly_shift = timedelta(days=3, hours=7)
+    hourly_shift = timedelta(minutes=11)
     fn_set_all = AfExecutionDateFn(
         upstream_schedule_tag=_WeeklyScheduleTag(weekly_shift),
         downstream_schedule_tag=_HourlyScheduleTag(hourly_shift),
         wait_policy=WaitPolicy.all,
     ).get_execution_dates()
     assert len(fn_set_all) == 1
-    assert fn_set_all[0](execution_date_during_the_night) == datetime.datetime(
-        2023, 10, 1, 7, 0, 0
-    ) + datetime.timedelta(days=3)
-    assert fn_set_all[0](execution_date_during_the_night + datetime.timedelta(days=6)) == datetime.datetime(
-        2023, 10, 4, 7, 0, 0
-    )
+    assert fn_set_all[0](execution_date_during_the_night) == datetime(2023, 10, 1, 7, 0, 0) + timedelta(days=3)
+    assert fn_set_all[0](execution_date_during_the_night + timedelta(days=6)) == datetime(2023, 10, 4, 7, 0, 0)
 
 
 def test_hourly_on_monthly(execution_date_during_the_day, execution_date_during_the_night):
     assert calculate_task_to_wait_execution_date(
         execution_date_during_the_day,
-        self_cron=_HourlyScheduleTag.default_cron_expression,
-        upstream_cron=_MonthlyScheduleTag.default_cron_expression,
-    ) == datetime.datetime(2023, 9, 1, 0, 0, 0)
+        self_schedule=_HourlyScheduleTag(),
+        upstream_schedule=_MonthlyScheduleTag(),
+    ) == datetime(2023, 9, 1, 0, 0, 0)
     assert calculate_task_to_wait_execution_date(
         execution_date_during_the_night,
-        self_cron=_HourlyScheduleTag.default_cron_expression,
-        upstream_cron=_MonthlyScheduleTag.default_cron_expression,
-    ) == datetime.datetime(2023, 9, 1, 0, 0, 0)
+        self_schedule=_HourlyScheduleTag(),
+        upstream_schedule=_MonthlyScheduleTag(),
+    ) == datetime(2023, 9, 1, 0, 0, 0)
 
     assert calculate_task_to_wait_execution_date(
         execution_date_during_the_day,
-        self_cron=_HourlyScheduleTag.default_cron_expression,
-        upstream_cron=_MonthlyScheduleTag(datetime.timedelta(hours=9)).cron_expression(),
-    ) == datetime.datetime(2023, 9, 1, 9, 0, 0)
+        self_schedule=_HourlyScheduleTag(),
+        upstream_schedule=_MonthlyScheduleTag(timedelta(hours=9)),
+    ) == datetime(2023, 9, 1, 9, 0, 0)
     assert calculate_task_to_wait_execution_date(
         execution_date_during_the_night,
-        self_cron=_HourlyScheduleTag.default_cron_expression,
-        upstream_cron=_MonthlyScheduleTag(datetime.timedelta(hours=7)).cron_expression(),
-    ) == datetime.datetime(2023, 9, 1, 7, 0, 0)
+        self_schedule=_HourlyScheduleTag(),
+        upstream_schedule=_MonthlyScheduleTag(timedelta(hours=7)),
+    ) == datetime(2023, 9, 1, 7, 0, 0)
 
-    monthly_shift = datetime.timedelta(days=3, hours=7)
-    hourly_shift = datetime.timedelta(minutes=11)
+    monthly_shift = timedelta(days=3, hours=7)
+    hourly_shift = timedelta(minutes=11)
     fn_set_last = AfExecutionDateFn(
         upstream_schedule_tag=_MonthlyScheduleTag(monthly_shift),
         downstream_schedule_tag=_HourlyScheduleTag(hourly_shift),
@@ -286,23 +283,23 @@ def test_hourly_on_monthly(execution_date_during_the_day, execution_date_during_
 
 def test_monthly_on_hourly(execution_date_during_the_day, execution_date_during_the_night):
     assert calculate_task_to_wait_execution_date(
-        datetime.datetime(2023, 10, 1, 5, 15, 0),
-        self_cron=CronExpression('15 5 1 * *'),
-        upstream_cron=CronExpression('45 * * * *'),
-    ) == datetime.datetime(2023, 11, 1, 4, 45, 0)
+        datetime(2023, 10, 1, 5, 15, 0),
+        self_schedule=_MonthlyScheduleTag(timedelta(hours=5, minutes=15, days=1)),
+        upstream_schedule=_HourlyScheduleTag(timedelta(minutes=45)),
+    ) == datetime(2023, 11, 1, 4, 45, 0)
     fn_set_last = AfExecutionDateFn(
         upstream_schedule_tag=_HourlyScheduleTag(),
         downstream_schedule_tag=_MonthlyScheduleTag(),
         wait_policy=WaitPolicy.last,
     ).get_execution_dates()
     assert len(fn_set_last) == 1
-    assert fn_set_last[0](execution_date_during_the_night) == datetime.datetime(2023, 10, 31, 23, 0, 0)
-    assert fn_set_last[0](execution_date_during_the_night + datetime.timedelta(days=3)) == datetime.datetime(
+    assert fn_set_last[0](execution_date_during_the_night) == datetime(2023, 10, 31, 23, 0, 0)
+    assert fn_set_last[0](execution_date_during_the_night + timedelta(days=3)) == datetime(
         2023, 10, 28, 23, 0, 0
-    ) + datetime.timedelta(days=3)
-    assert fn_set_last[0](execution_date_during_the_night + datetime.timedelta(days=6)) == datetime.datetime(
+    ) + timedelta(days=3)
+    assert fn_set_last[0](execution_date_during_the_night + timedelta(days=6)) == datetime(
         2023, 10, 25, 23, 0, 0
-    ) + datetime.timedelta(days=6)
+    ) + timedelta(days=6)
 
     fn_set_all = AfExecutionDateFn(
         upstream_schedule_tag=_HourlyScheduleTag(),
@@ -314,23 +311,23 @@ def test_monthly_on_hourly(execution_date_during_the_day, execution_date_during_
 
 def test_monthly_on_daily(execution_date_during_the_day, execution_date_during_the_night):
     assert calculate_task_to_wait_execution_date(
-        datetime.datetime(2023, 10, 12, 5, 15, 0),
-        self_cron=CronExpression('15 5 12 * *'),
-        upstream_cron=CronExpression('45 7 * * *'),
-    ) == datetime.datetime(2023, 11, 11, 7, 45, 0)
+        datetime(2023, 10, 12, 5, 15, 0),
+        self_schedule=_MonthlyScheduleTag(timedelta(hours=5, minutes=15, days=12)),
+        upstream_schedule=_DailyScheduleTag(timedelta(hours=7, minutes=45)),
+    ) == datetime(2023, 11, 11, 7, 45, 0)
     fn_set_last = AfExecutionDateFn(
         upstream_schedule_tag=_DailyScheduleTag(),
         downstream_schedule_tag=_MonthlyScheduleTag(),
         wait_policy=WaitPolicy.last,
     ).get_execution_dates()
     assert len(fn_set_last) == 1
-    assert fn_set_last[0](execution_date_during_the_night) == datetime.datetime(2023, 10, 31)
-    assert fn_set_last[0](execution_date_during_the_night + datetime.timedelta(days=3)) == datetime.datetime(
+    assert fn_set_last[0](execution_date_during_the_night) == datetime(2023, 10, 31)
+    assert fn_set_last[0](execution_date_during_the_night + timedelta(days=3)) == datetime(
         2023, 10, 28, 0, 0, 0
-    ) + datetime.timedelta(days=3)
-    assert fn_set_last[0](execution_date_during_the_night + datetime.timedelta(days=6)) == datetime.datetime(
-        2023, 10, 25
-    ) + datetime.timedelta(days=6)
+    ) + timedelta(days=3)
+    assert fn_set_last[0](execution_date_during_the_night + timedelta(days=6)) == datetime(2023, 10, 25) + timedelta(
+        days=6
+    )
 
     fn_set_all = AfExecutionDateFn(
         upstream_schedule_tag=_DailyScheduleTag(),
@@ -338,29 +335,25 @@ def test_monthly_on_daily(execution_date_during_the_day, execution_date_during_t
         wait_policy=WaitPolicy.all,
     ).get_execution_dates()
     assert len(fn_set_all) == 30
-    assert fn_set_all[0](execution_date_during_the_night.replace(day=1)) == datetime.datetime(2023, 10, 1)
-    assert fn_set_all[-1](execution_date_during_the_night.replace(day=1)) == datetime.datetime(2023, 10, 30)
+    assert fn_set_all[0](execution_date_during_the_night.replace(day=1)) == datetime(2023, 10, 1)
+    assert fn_set_all[-1](execution_date_during_the_night.replace(day=1)) == datetime(2023, 10, 30)
 
 
 def test_daily_on_monthly(execution_date_during_the_day, execution_date_during_the_night):
     assert calculate_task_to_wait_execution_date(
-        datetime.datetime(2023, 10, 12, 5, 15, 0),
-        self_cron=CronExpression('15 5 * * *'),
-        upstream_cron=CronExpression('45 7 13 * *'),
-    ) == datetime.datetime(2023, 8, 13, 7, 45, 0)
+        datetime(2023, 10, 12, 5, 15, 0),
+        self_schedule=_DailyScheduleTag(timedelta(hours=5, minutes=15)),
+        upstream_schedule=_MonthlyScheduleTag(timedelta(hours=7, minutes=45, days=13)),
+    ) == datetime(2023, 8, 13, 7, 45, 0)
     fn_set_last = AfExecutionDateFn(
         upstream_schedule_tag=_MonthlyScheduleTag(),
         downstream_schedule_tag=_DailyScheduleTag(),
         wait_policy=WaitPolicy.last,
     ).get_execution_dates()
     assert len(fn_set_last) == 1
-    assert fn_set_last[0](execution_date_during_the_night) == datetime.datetime(2023, 9, 1, 0, 0, 0)
-    assert fn_set_last[0](execution_date_during_the_night + datetime.timedelta(days=3)) == datetime.datetime(
-        2023, 9, 1, 0, 0, 0
-    )
-    assert fn_set_last[0](execution_date_during_the_night + datetime.timedelta(days=6)) == datetime.datetime(
-        2023, 9, 1, 0, 0, 0
-    )
+    assert fn_set_last[0](execution_date_during_the_night) == datetime(2023, 9, 1, 0, 0, 0)
+    assert fn_set_last[0](execution_date_during_the_night + timedelta(days=3)) == datetime(2023, 9, 1, 0, 0, 0)
+    assert fn_set_last[0](execution_date_during_the_night + timedelta(days=6)) == datetime(2023, 9, 1, 0, 0, 0)
 
     fn_set_all = AfExecutionDateFn(
         upstream_schedule_tag=_MonthlyScheduleTag(),
@@ -368,8 +361,6 @@ def test_daily_on_monthly(execution_date_during_the_day, execution_date_during_t
         wait_policy=WaitPolicy.all,
     ).get_execution_dates()
     assert len(fn_set_all) == 1
-    assert fn_set_all[0](execution_date_during_the_night) == datetime.datetime(2023, 9, 1, 0, 0, 0)
+    assert fn_set_all[0](execution_date_during_the_night) == datetime(2023, 9, 1, 0, 0, 0)
 
-    assert fn_set_last[0](execution_date_during_the_night + datetime.timedelta(days=6)) == datetime.datetime(
-        2023, 9, 1, 0, 0, 0
-    )
+    assert fn_set_last[0](execution_date_during_the_night + timedelta(days=6)) == datetime(2023, 9, 1, 0, 0, 0)


### PR DESCRIPTION
Fixes how cron expressions are compared. Using `now()` can lead to incorrect corner cases, so cron expressions could be compared just by their parts.