### PR TITLE
fix: change dbt_run_model DAG name for multi-project usage

### DIFF
--- a/dbt_af/dags.py
+++ b/dbt_af/dags.py
@@ -55,7 +55,8 @@ def dbt_main_dags(graph: DbtAfGraph) -> dict[str, DAG]:
 
 
 def dbt_run_model_dag(config: Config) -> dict[str, DAG]:
-    dag_name = 'dbt_run_model'
+    dbt_project_name = config.dbt_project.dbt_project_name
+    dag_name = f'{dbt_project_name}_dbt_run_model'
 
     dag_callbacks, task_callbacks = collect_af_custom_callbacks(config)
     dag = DAG(
@@ -66,7 +67,7 @@ def dbt_run_model_dag(config: Config) -> dict[str, DAG]:
         catchup=False,
         default_args=DEFAULT_DAG_ARGS,
         max_active_runs=config.max_active_dag_runs,
-        tags=['dbt', 'system'],
+        tags=[dbt_project_name, 'dbt', 'system'],
         params={
             DBT_MODEL_DAG_PARAM: Param('', type='string'),
             'start_dttm': Param('2000-01-01T00:00:00', type='string'),

--- a/examples/basic_project.md
+++ b/examples/basic_project.md
@@ -25,7 +25,7 @@ The main purpose of these DAGs is to backfill the data in case of any issues wit
 To backfill any data interval, you need just to trigger the DAG with the specific date interval, and it will run all the models with tests in one domain.
 
 ### Single model DAG
-By default `dbt-af` will generate unified DAG with name `dbt_run_model`. This DAG is made for manual run of a single model. It's useful for debugging or backfilling a single model with specified date interval.
+By default `dbt-af` will generate unified DAG with name `<dbt_project_name>_dbt_run_model`. This DAG is made for manual run of a single model. It's useful for debugging or backfilling a single model with specified date interval.
 
 To turn off just set `include_single_model_manual_dag` to `False` in the `dbt-af` configuration.
 ```python

--- a/tests/test_sensors_wait_fns.py
+++ b/tests/test_sensors_wait_fns.py
@@ -306,7 +306,7 @@ def test_monthly_on_hourly(execution_date_during_the_day, execution_date_during_
         downstream_schedule_tag=_MonthlyScheduleTag(),
         wait_policy=WaitPolicy.all,
     ).get_execution_dates()
-    assert len(fn_set_all) == 720
+    assert 28 * 24 <= len(fn_set_all) == 31 * 24
 
 
 def test_monthly_on_daily(execution_date_during_the_day, execution_date_during_the_night):
@@ -334,9 +334,9 @@ def test_monthly_on_daily(execution_date_during_the_day, execution_date_during_t
         downstream_schedule_tag=_MonthlyScheduleTag(),
         wait_policy=WaitPolicy.all,
     ).get_execution_dates()
-    assert len(fn_set_all) == 30
+    assert 28 <= len(fn_set_all) <= 31
     assert fn_set_all[0](execution_date_during_the_night.replace(day=1)) == datetime(2023, 10, 1)
-    assert fn_set_all[-1](execution_date_during_the_night.replace(day=1)) == datetime(2023, 10, 30)
+    assert fn_set_all[-1](execution_date_during_the_night.replace(day=1)) == datetime(2023, 10, 31)
 
 
 def test_daily_on_monthly(execution_date_during_the_day, execution_date_during_the_night):


### PR DESCRIPTION
Fixed a bug in dbt_run_model_dag that occurred when using two DBT projects in a single Airflow instance.