### PR TITLE
feat: add `env` field to dbt model's config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ logs/
 **/__pycache__/**
 
 .coverage*
+
+**/dist/
+**/build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.0
+Features:
+- add `env` field to dbt model's config to specify additional environment variables
+
 ## v0.9.3
 Fixes:
 - change dbt_run_model DAG name for multi-project usage (https://github.com/Toloka/dbt-af/pull/39)

--- a/dbt_af/__init__.py
+++ b/dbt_af/__init__.py
@@ -4,6 +4,6 @@ __all__ = [
 ]
 
 # note that this version is maintained by the release manager - do not update it manually
-__version__ = '0.9.3'
+__version__ = '0.10.0'
 
 from . import conf, dags  # noqa

--- a/dbt_af/builder/dag_components.py
+++ b/dbt_af/builder/dag_components.py
@@ -242,6 +242,7 @@ class DagModel(DagComponent):
             model_type=self.dbt_node.model_type,
             target_environment=self.target_environment,
             dbt_af_config=self.domain_dag.config,
+            env=self.dbt_node.config.env,
             **self._af_callbacks,
         )
 
@@ -258,6 +259,7 @@ class DagModel(DagComponent):
             dag=self.domain_dag.af_dag,
             target_details=self.dbt_node.target_details,
             dbt_af_config=self.domain_dag.config,
+            env=self.dbt_node.config.env,
         )
 
     def _create_runner_task(self) -> DbtRun | DbtKubernetesPodOperator:

--- a/dbt_af/operators/base.py
+++ b/dbt_af/operators/base.py
@@ -51,6 +51,7 @@ class DbtBaseOperator(BashOperator):
         debug_flg: bool = True,
         pool: Optional[str] = None,
         retry_policy: Optional[RetryPolicy] = None,
+        env: dict[str, str] | None = None,
         **kwargs,
     ) -> None:
         self.debug = '--debug' if debug_flg else ''
@@ -71,7 +72,7 @@ class DbtBaseOperator(BashOperator):
         )
         super().__init__(
             max_active_tis_per_dag=max_active_tis_per_dag,
-            env=init_environment(self.dbt_af_config),
+            env=init_environment(self.dbt_af_config) | (env or {}),
             pool=af_pool,
             append_env=True,
             bash_command=self.generate_bash(**self.__dict__),

--- a/dbt_af/operators/kubernetes_pod.py
+++ b/dbt_af/operators/kubernetes_pod.py
@@ -27,6 +27,7 @@ class DbtKubernetesPodOperator(KubernetesPodOperator):
         dbt_model_path: str,
         target_details: KubernetesTarget,
         dbt_af_config: Config,
+        env: dict[str, str] | None = None,
         *args,
         **kwargs,
     ):
@@ -44,6 +45,7 @@ class DbtKubernetesPodOperator(KubernetesPodOperator):
             log_events_on_failure=True,
             do_xcom_push=True,
             startup_timeout_seconds=1200,
+            env_vars=[k8s.V1EnvVar(name=k, value=v) for k, v in (env or {}).items()],
             namespace=conf.get('kubernetes_executor', 'NAMESPACE'),
             **dbt_af_config.retries_config.k8s_task_retry_policy.as_dict(),
             **kwargs,

--- a/dbt_af/parser/dbt_node_model.py
+++ b/dbt_af/parser/dbt_node_model.py
@@ -124,6 +124,8 @@ class DbtNodeConfig(pydantic.BaseModel):
         default_factory=lambda: defaultdict(DependencyConfig)
     )
 
+    env: dict[str, str] = pydantic.Field(default_factory=dict)
+
     py_cluster: Optional[str]
     sql_cluster: Optional[str]
     daily_sql_cluster: Optional[str]

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -9,9 +9,10 @@
     4. [disable_from_dttm](#disable_from_dttm-_str_)
     5. [domain_start_date](#domain_start_date-_str_)
     6. [dbt_target](#dbt_target-_str_)
-    7. [py_cluster, sql_cluster, daily_sql_cluster, bf_cluster](#py_cluster-sql_cluster-daily_sql_cluster-bf_cluster-_str_)
-    8. [maintenance](#maintenance-_dbtafmaintenanceconfig_)
-    9. [tableau_refresh_tasks](#tableau_refresh_tasks-_listtableaurefreshtaskconfig_)
+    7. [env](#env-dictstr-str)
+    8. [py_cluster, sql_cluster, daily_sql_cluster, bf_cluster](#py_cluster-sql_cluster-daily_sql_cluster-bf_cluster-_str_)
+    9. [maintenance](#maintenance-_dbtafmaintenanceconfig_)
+    10. [tableau_refresh_tasks](#tableau_refresh_tasks-_listtableaurefreshtaskconfig_)
 
 ## dbt model config options
 
@@ -110,7 +111,7 @@ models:
 > [!NOTE]
 > To use [airflow templates](https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html#) in the `env`
 > values, you need to use double curly braces `{{ '{{' }}` and `{{ '}}' }}` to escape them.
-> 
+>
 > Pattern: `{{'<airflow_template>'}}` --> `{{ '{{<airflow_template>' }}`
 
 ###### `py_cluster`, `sql_cluster`, `daily_sql_cluster`, `bf_cluster` (_str_)

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -112,7 +112,7 @@ models:
 > To use [airflow templates](https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html#) in the `env`
 > values, you need to use double curly braces `{{ '{{' }}` and `{{ '}}' }}` to escape them.
 >
-> Pattern: `{{'<airflow_template>'}}` --> `{{ '{{<airflow_template>' }}`
+> Pattern: `{{<airflow_template>}}` --> `{{ '{{<airflow_template>' }}`
 
 ###### `py_cluster`, `sql_cluster`, `daily_sql_cluster`, `bf_cluster` (_str_)
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -31,7 +31,7 @@ Tag to define the schedule of the model. Supported tags are:
 - **@manual** - special tag to mark the model has no schedule. Read more about it
   in [tutorial](../examples/manual_scheduling.md)
 
-###### `dependencies` (_dict[str, DependencyConfig]_)
+###### dependencies (_dict[str, DependencyConfig]_)
 
 Сonfig to define how the model depends on other models.
 You can find the tutorial [here](../examples/dependencies_management.md)
@@ -60,17 +60,17 @@ models:
           wait_policy: last
 ```
 
-###### `enable_from_dttm` (_str_)
+###### enable_from_dttm (_str_)
 
 Date and time when the model should be enabled. The model will be skipped until this
 date. The format is `YYYY-MM-DDTHH:MM:SS`. Can be used in combination with `disable_from_dttm`
 
-###### `disable_from_dttm` (_str_)
+###### disable_from_dttm (_str_)
 
 Date and time when the model should be disabled. The model will be skipped after this
 date. The format is `YYYY-MM-DDTHH:MM:SS`. Can be used in combination with `enable_from_dttm`
 
-###### `domain_start_date` (_str_)
+###### domain_start_date (_str_)
 
 Date when the domain of the model starts. Option is used to reduce number of catchup
 DagRuns in Airflow. The format is `YYYY-MM-DDTHH:MM:SS`. Each domain selects minimal `domain_start_date` from all its
@@ -85,12 +85,12 @@ models:
       domain_start_date: "2024-01-01T00:00:00"
 ```
 
-###### `dbt_target` (_str_)
+###### dbt_target (_str_)
 
 Name of the dbt target to use for this exact model. If not set, the default target will be used.
 You can find more info in [tutorial](../examples/advanced_project.md#explicit-dbt-target)
 
-###### `env` (dict[str, str])
+###### env (dict[str, str])
 
 Additional environment variables to pass to the runtime.
 All variable values are passed first to dbt jinja rendering and then to the airflow rendering.
@@ -114,7 +114,7 @@ models:
 >
 > Pattern: `{{<airflow_template>}}` --> `{{ '{{<airflow_template>' }}`
 
-###### `py_cluster`, `sql_cluster`, `daily_sql_cluster`, `bf_cluster` (_str_)
+###### py_cluster, sql_cluster, daily_sql_cluster, bf_cluster (_str_)
 
 [resolving](../examples/advanced_project.md#how-is-the-target-determined) dbt target is based on these targets
 if explicitly not set. Usually, these parameters are set in the `dbt_project.yml` file for different domains:
@@ -131,7 +131,7 @@ models:
       bf_cluster: "bf_cluster"
 ```  
 
-###### `maintenance` (_DbtAFMaintenanceConfig_)
+###### maintenance (_DbtAFMaintenanceConfig_)
 
 Config to define maintenance tasks for the model.
 
@@ -150,7 +150,7 @@ models:
         expiration_timeout: 10
 ```
 
-###### `tableau_refresh_tasks` (_list[TableauRefreshTaskConfig]_)
+###### tableau_refresh_tasks (_list[TableauRefreshTaskConfig]_)
 
 List of Tableau refresh tasks.
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -3,67 +3,36 @@
 ## Table of Contents
 
 1. [Model Config](#dbt-model-config-options)
-    1. [DependencyConfig](#dependencyconfig)
-    2. [DbtAFMaintenanceConfig](#dbtafmaintenanceconfig)
-    3. [TableauRefreshTaskConfig](#tableaurefreshtaskconfig)
+    1. [schedule](#schedule)
+    2. [dependencies](#dependencies-_dictstr-dependencyconfig_)
+    3. [enable_from_dttm](#enable_from_dttm-_str_)
+    4. [disable_from_dttm](#disable_from_dttm-_str_)
+    5. [domain_start_date](#domain_start_date-_str_)
+    6. [dbt_target](#dbt_target-_str_)
+    7. [py_cluster, sql_cluster, daily_sql_cluster, bf_cluster](#py_cluster-sql_cluster-daily_sql_cluster-bf_cluster-_str_)
+    8. [maintenance](#maintenance-_dbtafmaintenanceconfig_)
+    9. [tableau_refresh_tasks](#tableau_refresh_tasks-_listtableaurefreshtaskconfig_)
 
 ## dbt model config options
 
 Model's config is an entrypoint to finetune the behavior of the model. It can be used to define the following options:
 
-- `schedule` (_str_): tag to define the schedule of the model. Supported tags are:
-    1. **@monthly** model will be run once a month on the first day of the month at midnight
-       (equals to `0 0 1 * *` cron schedule)
-    2. **@weekly** model will be run once a week on Sunday at midnight (equals to `0 0 * * 0` cron schedule)
-    3. **@daily** model will be run once a day at midnight (equals to `0 0 * * *` cron schedule)
-    4. **@hourly** model will be run once an hour at the beginning of the hour (equals to `0 * * * *` cron schedule)
-    5. **@every15minutes** model will be run every 15 minutes (equals to `*/15 * * * *` cron schedule)
-    6. **@manual** - special tag to mark the model has no schedule. Read more about it
-       in [tutorial](../examples/manual_scheduling.md)
-- `dependencies` (_dict[str, DependencyConfig]_): config to define how the model depends on other models. Read more
-  about [DependencyConfig](#dependencyconfig)
-- `enable_from_dttm` (_str_): date and time when the model should be enabled. The model will be skipped until this
-  date. The format is `YYYY-MM-DDTHH:MM:SS`. Can be used in combination with `disable_from_dttm`
-- `disable_from_dttm` (_str_): date and time when the model should be disabled. The model will be skipped after this
-  date. The format is `YYYY-MM-DDTHH:MM:SS`. Can be used in combination with `enable_from_dttm`
-- `domain_start_date` (_str_): date when the domain of the model starts. Option is used to reduce number of catchup
-  DagRuns in Airflow. The format is `YYYY-MM-DDTHH:MM:SS`. Each domain selects minimal `domain_start_date` from all its
-  models. Best place to set this option is `dbt_project.yml` file:
+###### schedule
 
-**_dbt_project.yml_**
+Tag to define the schedule of the model. Supported tags are:
 
-```yaml
-models:
-  project_name:
-    domain_name:
-      domain_start_date: "2024-01-01T00:00:00"
-```
+- **@monthly** model will be run once a month on the first day of the month at midnight
+  (equals to `0 0 1 * *` cron schedule)
+- **@weekly** model will be run once a week on Sunday at midnight (equals to `0 0 * * 0` cron schedule)
+- **@daily** model will be run once a day at midnight (equals to `0 0 * * *` cron schedule)
+- **@hourly** model will be run once an hour at the beginning of the hour (equals to `0 * * * *` cron schedule)
+- **@every15minutes** model will be run every 15 minutes (equals to `*/15 * * * *` cron schedule)
+- **@manual** - special tag to mark the model has no schedule. Read more about it
+  in [tutorial](../examples/manual_scheduling.md)
 
-- `dbt_target` (_str_): name of the dbt target to use for this exact model. If not set, the default target will be used.
-  You can find more info in [tutorial](../examples/advanced_project.md#explicit-dbt-target)
-- `py_cluster`, `sql_cluster`, `daily_sql_cluster`, `bf_cluster` (_str_):
-  [resolving](../examples/advanced_project.md#how-is-the-target-determined) dbt target is based on these targets
-  if explicitly not set. Usually, these parameters are set in the `dbt_project.yml` file for different domains:
+###### `dependencies` (_dict[str, DependencyConfig]_)
 
-**_dbt_project.yml_**
-
-```yaml
-models:
-  project_name:
-    domain_name:
-      py_cluster: "py_cluster"
-      sql_cluster: "sql_cluster"
-      daily_sql_cluster: "daily_sql_cluster"
-      bf_cluster: "bf_cluster"
-```  
-
-- `maintenance` (_DbtAFMaintenanceConfig_): config to define maintenance tasks for the model. Read more about
-  [DbtAFMaintenanceConfig](#dbtafmaintenanceconfig)
-- `tableau_refresh_tasks` (_list[TableauRefreshTaskConfig]_): list of Tableau refresh tasks. Read more about
-  [TableauRefreshTaskConfig](#tableaurefreshtaskconfig)
-
-### DependencyConfig
-
+Сonfig to define how the model depends on other models.
 You can find the tutorial [here](../examples/dependencies_management.md)
 
 For each dependency, you can specify the following options:
@@ -77,9 +46,9 @@ For each dependency, you can specify the following options:
 
 Example:
 
-**_dmn_jaffle_analytics.ods.orders.yml_**
-
 ```yaml
+# dmn_jaffle_analytics.ods.orders.yml
+
 models:
   - name: dmn_jaffle_analytics.ods.orders
     config:
@@ -90,15 +59,88 @@ models:
           wait_policy: last
 ```
 
-### DbtAFMaintenanceConfig
+###### `enable_from_dttm` (_str_)
+
+Date and time when the model should be enabled. The model will be skipped until this
+date. The format is `YYYY-MM-DDTHH:MM:SS`. Can be used in combination with `disable_from_dttm`
+
+###### `disable_from_dttm` (_str_)
+
+Date and time when the model should be disabled. The model will be skipped after this
+date. The format is `YYYY-MM-DDTHH:MM:SS`. Can be used in combination with `enable_from_dttm`
+
+###### `domain_start_date` (_str_)
+
+Date when the domain of the model starts. Option is used to reduce number of catchup
+DagRuns in Airflow. The format is `YYYY-MM-DDTHH:MM:SS`. Each domain selects minimal `domain_start_date` from all its
+models. Best place to set this option is `dbt_project.yml` file:
+
+```yaml
+# dbt_project.yml
+
+models:
+  project_name:
+    domain_name:
+      domain_start_date: "2024-01-01T00:00:00"
+```
+
+###### `dbt_target` (_str_)
+
+Name of the dbt target to use for this exact model. If not set, the default target will be used.
+You can find more info in [tutorial](../examples/advanced_project.md#explicit-dbt-target)
+
+###### `env` (dict[str, str])
+
+Additional environment variables to pass to the runtime.
+All variable values are passed first to dbt jinja rendering and then to the airflow rendering.
+
+_Example:_
+
+```yaml
+# dmn_jaffle_analytics.ods.orders.yml
+
+models:
+  - name: dmn_jaffle_analytics.ods.orders
+    config:
+      env:
+        MY_ENV_VAR: "my_value"
+        MY_ENV_WITH_AF_RENDERING: "{{'{{ var.value.get(\'my.var\', \'fallback\') }}'}}"
+```
+
+> [!NOTE]
+> To use [airflow templates](https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html#) in the `env`
+> values, you need to use double curly braces `{{ '{{' }}` and `{{ '}}' }}` to escape them.
+> 
+> Pattern: `{{'<airflow_template>'}}` --> `{{ '{{<airflow_template>' }}`
+
+###### `py_cluster`, `sql_cluster`, `daily_sql_cluster`, `bf_cluster` (_str_)
+
+[resolving](../examples/advanced_project.md#how-is-the-target-determined) dbt target is based on these targets
+if explicitly not set. Usually, these parameters are set in the `dbt_project.yml` file for different domains:
+
+```yaml
+# dbt_project.yml
+
+models:
+  project_name:
+    domain_name:
+      py_cluster: "py_cluster"
+      sql_cluster: "sql_cluster"
+      daily_sql_cluster: "daily_sql_cluster"
+      bf_cluster: "bf_cluster"
+```  
+
+###### `maintenance` (_DbtAFMaintenanceConfig_)
+
+Config to define maintenance tasks for the model.
 
 You can find the tutorial [here](../examples/maintenance_and_source_freshness.md#maintenance-tasks).
 
 Example of configuration:
 
-**_dmn_jaffle_analytics.ods.orders.yml_**
-
 ```yaml
+# dmn_jaffle_analytics.ods.orders.yml
+
 models:
   - name: dmn_jaffle_analytics.ods.orders
     config:
@@ -107,12 +149,14 @@ models:
         expiration_timeout: 10
 ```
 
-### TableauRefreshTaskConfig
+###### `tableau_refresh_tasks` (_list[TableauRefreshTaskConfig]_)
+
+List of Tableau refresh tasks.
 
 Configuration to define Tableau refresh tasks. This will trigger Tableau refresh tasks after the model is successfully
 run.
 
-> [!NOTE] 
+> [!NOTE]
 > To use this feature, you need to install `dbt-af` with `tableau` extra.
 > ```bash
 > pip install dbt-af[tableau]
@@ -120,9 +164,9 @@ run.
 
 Example of configuration:
 
-**_dmn_jaffle_analytics.ods.orders.yml_**
-
 ```yaml
+# dmn_jaffle_analytics.ods.orders.yml
+
 models:
   - name: dmn_jaffle_analytics.ods.orders
     config:

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -105,7 +105,7 @@ models:
     config:
       env:
         MY_ENV_VAR: "my_value"
-        MY_ENV_WITH_AF_RENDERING: "{{'{{ var.value.get(\'my.var\', \'fallback\') }}'}}"
+        MY_ENV_WITH_AF_RENDERING: "{{'{{ var.value.get(\"my.var\", \"fallback\") }}'}}"
 ```
 
 > [!NOTE]

--- a/examples/dags/example_advanced_dbt_af_dag.py
+++ b/examples/dags/example_advanced_dbt_af_dag.py
@@ -19,6 +19,7 @@ config = Config(
     ),
     dbt_default_targets=DbtDefaultTargetsConfig(default_target='dev', default_for_tests_target='tests'),
     dag_start_date=pendulum.yesterday(),
+    include_single_model_manual_dag=False,
     is_dev=False,  # set to True if you want to turn on dry-run mode
     retries_config=RetriesConfig(
         default_retry_policy=RetryPolicy(retries=3, retry_delay=timedelta(minutes=5)),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dbt-af"
 # note that this version is maintained by the release manager - do not update it manually
-version = "0.9.3"
+version = "0.10.0"
 description = "Distibuted dbt runs on Apache Airflow"
 authors = [
     "Nikita Yurasov <nikitayurasov@toloka.ai>",


### PR DESCRIPTION
Features:
   - add `env` field to dbt model's config to specify additional environment variables

Example:
```yaml
# dmn_jaffle_analytics.ods.orders.yml
models:
  - name: dmn_jaffle_analytics.ods.orders
    config:
      env:
        MY_ENV_VAR: "my_value"
        MY_ENV_WITH_AF_RENDERING: "{{'{{ var.value.get(\"my.var\", \"fallback\") }}'}}"
```