### PR TITLE
feat: add schedule shift functionality to dbt node model

### DIFF
--- a/dbt_af/builder/dag_components.py
+++ b/dbt_af/builder/dag_components.py
@@ -6,7 +6,7 @@ from airflow.utils.task_group import TaskGroup
 
 from dbt_af.builder.domain_dag import DomainDag
 from dbt_af.builder.task_dependencies import DagDelayedDependencyRegistry
-from dbt_af.common.scheduling import ScheduleTag
+from dbt_af.common.scheduling import EScheduleTag
 from dbt_af.operators.branch import DbtBranchOperator, create_decision_path_function
 from dbt_af.operators.kubernetes_pod import DbtKubernetesPodOperator
 from dbt_af.operators.run import DbtRun, DbtSeed, DbtSnapshot, DbtTest
@@ -114,8 +114,8 @@ class DagComponent:
         return (
             dep.domain_dag != self.domain_dag
             and self.add_external_dependencies
-            and dep.domain_dag.schedule != ScheduleTag.manual()
-            and self.domain_dag.schedule != ScheduleTag.manual()
+            and dep.domain_dag.schedule != EScheduleTag.manual()
+            and self.domain_dag.schedule != EScheduleTag.manual()
         )
 
     def _init_dependencies_per_domain_af(self, delayed_deps: DagDelayedDependencyRegistry):

--- a/dbt_af/builder/domain_dag.py
+++ b/dbt_af/builder/domain_dag.py
@@ -7,7 +7,7 @@ from airflow.operators.python import BranchPythonOperator
 
 from dbt_af.builder.task_dependencies import RegistryDomainDependencies
 from dbt_af.common import constants
-from dbt_af.common.scheduling import BaseScheduleTag, ScheduleTag
+from dbt_af.common.scheduling import BaseScheduleTag, EScheduleTag
 from dbt_af.conf import Config
 
 
@@ -28,7 +28,7 @@ class DomainDag:
         catchup: bool = True,
     ):
         self.domain_name = domain_name
-        self._schedule = schedule or ScheduleTag.daily()
+        self._schedule = schedule or EScheduleTag.daily()
         self.config: Config = config or Config()
 
         self.additional_tags: list[str] = additional_tags or []
@@ -60,7 +60,7 @@ class DomainDag:
     def tags(self) -> list[str]:
         pure_domain_name = self.domain_name.split('__')[0]
         merged_tags = (self._base_tags or []) + [pure_domain_name, self.schedule.safe_name] + self.additional_tags
-        if self.schedule != ScheduleTag.manual() and constants.BACKFILL_TAG not in merged_tags:
+        if self.schedule != EScheduleTag.manual() and constants.BACKFILL_TAG not in merged_tags:
             merged_tags.append(constants.FRONTIER_TAG)
 
         return merged_tags
@@ -99,7 +99,7 @@ class BackfillDomainDag(DomainDag):
 
     @property
     def schedule(self) -> BaseScheduleTag:
-        return ScheduleTag.daily()
+        return EScheduleTag.daily()
 
     def wrap_dag_with_endpoints(self):
         """
@@ -139,7 +139,7 @@ class MaintenanceDomainDag(DomainDag):
 
     @property
     def schedule(self) -> BaseScheduleTag:
-        return ScheduleTag.daily()
+        return EScheduleTag.daily()
 
 
 class LargeTestsDomainDag(DomainDag):
@@ -162,7 +162,7 @@ class LargeTestsDomainDag(DomainDag):
 
     @property
     def schedule(self) -> BaseScheduleTag:
-        return ScheduleTag.daily()
+        return EScheduleTag.daily()
 
 
 class DomainDagFactory:

--- a/dbt_af/common/af_scheduling_utils.py
+++ b/dbt_af/common/af_scheduling_utils.py
@@ -67,9 +67,14 @@ def calculate_task_to_wait_execution_date(
     upstream_cron = upstream_schedule.cron_expression()
     interval_stop_dttm: datetime = croniter(self_cron.raw_cron_expression, execution_date).get_next(datetime)
 
-    if self_schedule < upstream_schedule or self_schedule.level == upstream_schedule.level:
+    if self_schedule < upstream_schedule:
         cron_iter = croniter(upstream_cron.raw_cron_expression, interval_stop_dttm)
         cron_iter.get_prev()
+        return cron_iter.get_prev(datetime)
+    if self_schedule == upstream_schedule:
+        if self_schedule.timeshift == upstream_schedule.timeshift:
+            return execution_date
+        cron_iter = croniter(upstream_cron.raw_cron_expression, execution_date)
         return cron_iter.get_prev(datetime)
 
     all_dts = list(

--- a/dbt_af/common/af_scheduling_utils.py
+++ b/dbt_af/common/af_scheduling_utils.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+from functools import partial
+from typing import Callable
+
+from croniter import croniter, croniter_range
+
+from dbt_af.common.scheduling import BaseScheduleTag
+from dbt_af.parser.dbt_node_model import WaitPolicy
+
+
+class _TaskScheduleMapping:
+    def __init__(self, wait_policy: WaitPolicy):
+        self.wait_policy = wait_policy
+
+        self._mapping = {}
+
+    def is_registered(self, upstream_schedule_tag: BaseScheduleTag, downstream_schedule_tag: BaseScheduleTag) -> bool:
+        return (upstream_schedule_tag.name, downstream_schedule_tag.name) in self._mapping
+
+    def add(
+        self,
+        upstream_schedule_tag: BaseScheduleTag,
+        downstream_schedule_tag: BaseScheduleTag,
+        fn: Callable | list[Callable],
+    ):
+        if not isinstance(fn, list):
+            fn = [fn]
+        self._mapping[(upstream_schedule_tag.name, downstream_schedule_tag.name)] = fn
+        return self
+
+    @staticmethod
+    def _update_upstream_cron_args(fn: partial, upstream: BaseScheduleTag, downstream: BaseScheduleTag):
+        if fn is None:
+            return
+
+        fn.keywords.update({'self_schedule': downstream, 'upstream_schedule': upstream})
+
+    def get(self, key: tuple[BaseScheduleTag, BaseScheduleTag], default=None) -> list[Callable | None]:
+        """
+        If the result function is None (or list of None),
+        it means that there is no need to find a specific upstream task, wait for the last one.
+        """
+        if not isinstance(default, list):
+            default = [default]
+        stream_names = (key[0].name, key[1].name)
+        fns = self._mapping.get(stream_names, default)
+        for fn in fns:
+            self._update_upstream_cron_args(fn, upstream=key[0], downstream=key[1])
+
+        return fns
+
+
+def calculate_task_to_wait_execution_date(
+    execution_date: datetime,
+    self_schedule: BaseScheduleTag,
+    upstream_schedule: BaseScheduleTag,
+    num_iter: int | None = None,
+):
+    """
+    this function calculates the correct nearest execution date for the upstream task to wait for.
+
+    :param num_iter: number of iterations to go back in time
+        by default it's None, which means that the function will return the last possible execution date.
+        this parameter is used for the 'all' wait policy to iterate over all possible execution dates
+    """
+    self_cron = self_schedule.cron_expression()
+    upstream_cron = upstream_schedule.cron_expression()
+    interval_stop_dttm: datetime = croniter(self_cron.raw_cron_expression, execution_date).get_next(datetime)
+
+    if self_schedule < upstream_schedule or self_schedule.level == upstream_schedule.level:
+        cron_iter = croniter(upstream_cron.raw_cron_expression, interval_stop_dttm)
+        cron_iter.get_prev()
+        return cron_iter.get_prev(datetime)
+
+    all_dts = list(
+        croniter_range(execution_date, interval_stop_dttm, upstream_cron.raw_cron_expression, ret_type=datetime)
+    )
+
+    if all_dts and all_dts[-1] == interval_stop_dttm:
+        all_dts.pop()
+
+    if num_iter is None:
+        return all_dts[-1]
+
+    return all_dts[num_iter]
+
+
+GLOBAL_TASK_SCHEDULE_MAPPINGS = {policy: _TaskScheduleMapping(policy) for policy in WaitPolicy}

--- a/dbt_af/common/cron.py
+++ b/dbt_af/common/cron.py
@@ -1,0 +1,95 @@
+import datetime
+
+from attrs import define, field
+from croniter import croniter, croniter_range
+
+
+@define(order=False)
+class CronExpression:
+    raw_cron_expression: str = field(validator=lambda _, __, val: croniter.is_valid(val))
+
+    def __eq__(self, other):
+        if not isinstance(other, (CronExpression, str)):
+            return NotImplemented
+        if isinstance(other, str):
+            return self.raw_cron_expression == other
+        return self.raw_cron_expression == other.raw_cron_expression
+
+    def distance_between_two_runs(self) -> datetime.timedelta:
+        """
+        Calculate the time difference between two consecutive runs of the cron expression.
+        """
+        now = datetime.datetime.now()
+        cron_iter = croniter(self.raw_cron_expression, now)
+        next_run = cron_iter.get_next(datetime.datetime)
+        after_next_run = cron_iter.get_next(datetime.datetime)
+        return after_next_run - next_run
+
+    def embeddings_number(self, other: 'CronExpression | None', is_upstream_bigger: bool) -> int:
+        """
+        Calculate how many times this cron expression can be embedded into another one over a given period.
+        """
+        if other is None:
+            return 0
+        if not isinstance(other, CronExpression):
+            raise ValueError(f'Comparison must be with another CronExpression, got {other}')
+        if is_upstream_bigger:
+            return 0
+
+        now = datetime.datetime.now()
+        self_cron_iter = croniter(self.raw_cron_expression, now)
+        start_interval = self_cron_iter.get_next(datetime.datetime)
+        end_interval = self_cron_iter.get_next(datetime.datetime)
+
+        dts = list(
+            croniter_range(
+                start_interval,
+                end_interval,
+                other.raw_cron_expression,
+                ret_type=datetime.datetime,
+                expand_from_start_time=True,
+            )
+        )
+        if dts and dts[-1] == end_interval:
+            # both ends are inclusive, so we need to remove the last element if it's equal to the end_interval
+            dts.pop()
+
+        return len(dts)
+
+    def _split_cron_expression(self) -> list[str]:
+        return self.raw_cron_expression.split()
+
+    @property
+    def minutes(self) -> int:
+        minutes_part = self._split_cron_expression()[0]
+        if minutes_part == '*':
+            return 0
+        return int(minutes_part)
+
+    @property
+    def hours(self) -> int:
+        hours_part = self._split_cron_expression()[1]
+        if hours_part == '*':
+            return 0
+        return int(hours_part)
+
+    @property
+    def days(self) -> int:
+        days_part = self._split_cron_expression()[2]
+        if days_part == '*':
+            return 1
+        return int(days_part)
+
+    @property
+    def months(self) -> int:
+        months_part = self._split_cron_expression()[3]
+        if months_part == '*':
+            return 1
+        return int(months_part)
+
+    @property
+    def weekdays(self) -> int:
+        weekdays_part = self._split_cron_expression()[4]
+        if weekdays_part == '*':
+            return 0
+        return int(weekdays_part)

--- a/dbt_af/common/scheduling.py
+++ b/dbt_af/common/scheduling.py
@@ -74,9 +74,9 @@ class BaseScheduleTag(ABC):
 
     def __eq__(self, other: 'str | BaseScheduleTag'):
         if isinstance(other, str):
-            return self.name == other
+            return self.base_name == other
         if isinstance(other, BaseScheduleTag):
-            return self.name == other.name and self.timeshift == other.timeshift
+            return self.base_name == other.base_name
         raise TypeError(f'Cannot compare {self} with {other}')
 
     @property
@@ -231,6 +231,10 @@ class EScheduleTag(Enum):
     @property
     def name(self):
         return self.value.name
+
+    @property
+    def base_name(self):
+        return self.value.base_name
 
     @property
     def level(self):

--- a/dbt_af/common/scheduling.py
+++ b/dbt_af/common/scheduling.py
@@ -131,6 +131,8 @@ class BaseScheduleTag(ABC):
     def __lt__(self, other):
         if not isinstance(other, BaseScheduleTag):
             return NotImplemented
+        if self.level == other.level:
+            return self.timeshift < other.timeshift
         return self.level < other.level
 
     def __eq__(self, other: Union[str, 'BaseScheduleTag']):

--- a/dbt_af/common/scheduling.py
+++ b/dbt_af/common/scheduling.py
@@ -166,6 +166,17 @@ class BaseScheduleTag(ABC):
             return None
         return CronExpression(af_schedule)
 
+    def update_name_with_shift(self) -> str:
+        full_days_shift, full_hours_shift, rest_minutes_shift = self.split_timeshift()
+        shifts = [
+            ('day', full_days_shift),
+            ('hour', full_hours_shift),
+            ('minute', rest_minutes_shift),
+        ]
+        shift_parts = [f'{value}_{unit}s' for unit, value in shifts if value > 0]
+        if shift_parts:
+            self.name += '_shift_' + '_'.join(shift_parts)
+
 
 class _MonthlyScheduleTag(BaseScheduleTag):
     name = '@monthly'
@@ -174,6 +185,8 @@ class _MonthlyScheduleTag(BaseScheduleTag):
 
     def __init__(self, timeshift: Optional[datetime.timedelta] = None):
         self.timeshift = timeshift or self.default_timeshift
+        if timeshift:
+            self.update_name_with_shift()
 
     def _af_repr_impl(self, full_days_shift: int, full_hours_shift: int, rest_minutes_shift: int):
         """
@@ -201,6 +214,8 @@ class _WeeklyScheduleTag(BaseScheduleTag):
 
     def __init__(self, timeshift: Optional[datetime.timedelta] = None):
         self.timeshift = timeshift or self.default_timeshift
+        if timeshift:
+            self.update_name_with_shift()
 
     def _af_repr_impl(self, full_days_shift: int, full_hours_shift: int, rest_minutes_shift: int):
         """
@@ -220,6 +235,8 @@ class _DailyScheduleTag(BaseScheduleTag):
 
     def __init__(self, timeshift: Optional[datetime.timedelta] = None):
         self.timeshift = timeshift or self.default_timeshift
+        if timeshift:
+            self.update_name_with_shift()
 
     def _af_repr_impl(self, full_days_shift: int, full_hours_shift: int, rest_minutes_shift: int):
         """
@@ -239,6 +256,8 @@ class _HourlyScheduleTag(BaseScheduleTag):
 
     def __init__(self, timeshift: Optional[datetime.timedelta] = None):
         self.timeshift = timeshift or self.default_timeshift
+        if timeshift:
+            self.update_name_with_shift()
 
     def _af_repr_impl(self, full_days_shift: int, full_hours_shift: int, rest_minutes_shift: int):
         """
@@ -258,6 +277,8 @@ class _Every15MinutesScheduleTag(BaseScheduleTag):
 
     def __init__(self, timeshift: Optional[datetime.timedelta] = None):
         self.timeshift = timeshift or self.default_timeshift
+        if timeshift:
+            self.update_name_with_shift()
 
     def _af_repr_impl(self, full_days_shift: int, full_hours_shift: int, rest_minutes_shift: int):
         """

--- a/dbt_af/common/scheduling.py
+++ b/dbt_af/common/scheduling.py
@@ -166,7 +166,10 @@ class BaseScheduleTag(ABC):
             return None
         return CronExpression(af_schedule)
 
-    def update_name_with_shift(self) -> str:
+    def try_update_name_with_shift(self) -> None:
+        if self.timeshift == self.default_timeshift:
+            return
+
         full_days_shift, full_hours_shift, rest_minutes_shift = self.split_timeshift()
         shifts = [
             ('day', full_days_shift),
@@ -185,8 +188,7 @@ class _MonthlyScheduleTag(BaseScheduleTag):
 
     def __init__(self, timeshift: Optional[datetime.timedelta] = None):
         self.timeshift = timeshift or self.default_timeshift
-        if timeshift:
-            self.update_name_with_shift()
+        self.try_update_name_with_shift()
 
     def _af_repr_impl(self, full_days_shift: int, full_hours_shift: int, rest_minutes_shift: int):
         """
@@ -214,8 +216,7 @@ class _WeeklyScheduleTag(BaseScheduleTag):
 
     def __init__(self, timeshift: Optional[datetime.timedelta] = None):
         self.timeshift = timeshift or self.default_timeshift
-        if timeshift:
-            self.update_name_with_shift()
+        self.try_update_name_with_shift()
 
     def _af_repr_impl(self, full_days_shift: int, full_hours_shift: int, rest_minutes_shift: int):
         """
@@ -235,8 +236,7 @@ class _DailyScheduleTag(BaseScheduleTag):
 
     def __init__(self, timeshift: Optional[datetime.timedelta] = None):
         self.timeshift = timeshift or self.default_timeshift
-        if timeshift:
-            self.update_name_with_shift()
+        self.try_update_name_with_shift()
 
     def _af_repr_impl(self, full_days_shift: int, full_hours_shift: int, rest_minutes_shift: int):
         """
@@ -256,8 +256,7 @@ class _HourlyScheduleTag(BaseScheduleTag):
 
     def __init__(self, timeshift: Optional[datetime.timedelta] = None):
         self.timeshift = timeshift or self.default_timeshift
-        if timeshift:
-            self.update_name_with_shift()
+        self.try_update_name_with_shift()
 
     def _af_repr_impl(self, full_days_shift: int, full_hours_shift: int, rest_minutes_shift: int):
         """
@@ -277,8 +276,7 @@ class _Every15MinutesScheduleTag(BaseScheduleTag):
 
     def __init__(self, timeshift: Optional[datetime.timedelta] = None):
         self.timeshift = timeshift or self.default_timeshift
-        if timeshift:
-            self.update_name_with_shift()
+        self.try_update_name_with_shift()
 
     def _af_repr_impl(self, full_days_shift: int, full_hours_shift: int, rest_minutes_shift: int):
         """

--- a/dbt_af/operators/base.py
+++ b/dbt_af/operators/base.py
@@ -14,13 +14,13 @@ from airflow.operators.bash import BashOperator
 from airflow.utils.context import Context
 
 from dbt_af.common.constants import DBT_COMPILE_POOL
-from dbt_af.common.scheduling import BaseScheduleTag, ScheduleTag
+from dbt_af.common.scheduling import BaseScheduleTag, EScheduleTag
 from dbt_af.common.utils import find_latest_log_file, init_environment
 from dbt_af.conf import Config, RetryPolicy
 
 
 def get_delay_by_schedule(schedule_tag):
-    if schedule_tag is not None and schedule_tag == ScheduleTag.hourly():
+    if schedule_tag is not None and schedule_tag == EScheduleTag.hourly():
         return {'execution_timeout': timedelta(minutes=60)}
     return {'execution_timeout': timedelta(hours=6)}
 

--- a/dbt_af/operators/sensors.py
+++ b/dbt_af/operators/sensors.py
@@ -96,7 +96,7 @@ def calculate_task_to_wait_execution_date(
     upstream_cron = upstream_schedule.cron_expression()
     interval_stop_dttm: datetime = croniter(self_cron.raw_cron_expression, execution_date).get_next(datetime)
 
-    if self_schedule < upstream_schedule:
+    if self_schedule < upstream_schedule or self_schedule.level == upstream_schedule.level:
         cron_iter = croniter(upstream_cron.raw_cron_expression, interval_stop_dttm)
         cron_iter.get_prev()
         return cron_iter.get_prev(datetime)

--- a/dbt_af/parser/dbt_node_model.py
+++ b/dbt_af/parser/dbt_node_model.py
@@ -12,7 +12,7 @@ except ModuleNotFoundError:
     import pydantic
 
 from dbt_af.common.constants import DOMAIN_DAG_START_DATE_FMT
-from dbt_af.common.scheduling import BaseScheduleTag, ScheduleTag
+from dbt_af.common.scheduling import BaseScheduleTag, EScheduleTag
 from dbt_af.common.utils import TestTag
 from dbt_af.conf import DbtDefaultTargetsConfig
 from dbt_af.parser.dbt_profiles import KubernetesTarget, Profile, Target, VenvTarget
@@ -119,7 +119,7 @@ class DbtNodeConfig(pydantic.BaseModel):
     post_hook: Optional[List[Dict[str, Any]]] = pydantic.Field(alias='post-hook', default_factory=list)
     pre_hook: Optional[List[Dict[str, Any]]] = pydantic.Field(alias='pre-hook', default_factory=list)
 
-    schedule: Optional[BaseScheduleTag] = pydantic.Field(default_factory=ScheduleTag.daily)
+    schedule: Optional[BaseScheduleTag] = pydantic.Field(default_factory=EScheduleTag.daily)
     schedule_shift: int = pydantic.Field(default=0)
     schedule_shift_unit: Literal['minute', 'hour', 'day'] = pydantic.Field(default='minute')
 
@@ -177,10 +177,10 @@ class DbtNodeConfig(pydantic.BaseModel):
             )
         ):
             timeshift = dt.timedelta(**{f'{values["schedule_shift_unit"]}s': values['schedule_shift']})
-        if values.get('schedule') not in [item.value().name for item in ScheduleTag]:
-            values['schedule'] = ScheduleTag.daily(timeshift=timeshift)
+        if values.get('schedule') not in [item.value().name for item in EScheduleTag]:
+            values['schedule'] = EScheduleTag.daily(timeshift=timeshift)
         else:
-            values['schedule'] = ScheduleTag[values['schedule'].lstrip('@')](timeshift=timeshift)
+            values['schedule'] = EScheduleTag[values['schedule'].lstrip('@')](timeshift=timeshift)
 
         return values
 
@@ -330,7 +330,7 @@ class DbtNode(pydantic.BaseModel):
             return default_dbt_targets.default_for_tests_target
 
         if len(self.config.pre_hook) == 0 and self.model_type == 'sql':
-            if self.config.schedule in (ScheduleTag.daily(), ScheduleTag.weekly()):
+            if self.config.schedule in (EScheduleTag.daily(), EScheduleTag.weekly()):
                 return self.config.daily_sql_cluster
 
             return self.config.sql_cluster

--- a/dbt_af/parser/dbt_node_model.py
+++ b/dbt_af/parser/dbt_node_model.py
@@ -177,7 +177,7 @@ class DbtNodeConfig(pydantic.BaseModel):
             )
         ):
             timeshift = dt.timedelta(**{f'{values["schedule_shift_unit"]}s': values['schedule_shift']})
-        if values.get('schedule') not in [item.value().name for item in EScheduleTag]:
+        if values.get('schedule') not in [item().name for item in EScheduleTag]:
             values['schedule'] = EScheduleTag.daily(timeshift=timeshift)
         else:
             values['schedule'] = EScheduleTag[values['schedule'].lstrip('@')](timeshift=timeshift)

--- a/dbt_af/parser/dbt_node_model.py
+++ b/dbt_af/parser/dbt_node_model.py
@@ -2,7 +2,7 @@ import datetime as dt
 import enum
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, DefaultDict, Dict, List, Optional, Union
+from typing import Any, DefaultDict, Dict, List, Literal, Optional, Union
 
 import pendulum
 
@@ -121,7 +121,7 @@ class DbtNodeConfig(pydantic.BaseModel):
 
     schedule: Optional[BaseScheduleTag] = pydantic.Field(default_factory=ScheduleTag.daily)
     schedule_shift: int = pydantic.Field(default=0)
-    schedule_shift_unit: str = pydantic.Field(default='minute')
+    schedule_shift_unit: Literal['minute', 'hour', 'day'] = pydantic.Field(default='minute')
 
     dependencies: Optional[DefaultDict[str, DependencyConfig]] = pydantic.Field(
         default_factory=lambda: defaultdict(DependencyConfig)

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -4,15 +4,17 @@
 
 1. [Model Config](#dbt-model-config-options)
     1. [schedule](#schedule)
-    2. [dependencies](#dependencies-_dictstr-dependencyconfig_)
-    3. [enable_from_dttm](#enable_from_dttm-_str_)
-    4. [disable_from_dttm](#disable_from_dttm-_str_)
-    5. [domain_start_date](#domain_start_date-_str_)
-    6. [dbt_target](#dbt_target-_str_)
-    7. [env](#env-dictstr-str)
-    8. [py_cluster, sql_cluster, daily_sql_cluster, bf_cluster](#py_cluster-sql_cluster-daily_sql_cluster-bf_cluster-_str_)
-    9. [maintenance](#maintenance-_dbtafmaintenanceconfig_)
-    10. [tableau_refresh_tasks](#tableau_refresh_tasks-_listtableaurefreshtaskconfig_)
+    2. [schedule_shift](#schedule_shift-_str_)
+    3. [schedule_shift_unit](#schedule_shift_unit-_str_)
+    4. [dependencies](#dependencies-_dictstr-dependencyconfig_)
+    5. [enable_from_dttm](#enable_from_dttm-_str_)
+    6. [disable_from_dttm](#disable_from_dttm-_str_)
+    7. [domain_start_date](#domain_start_date-_str_)
+    8. [dbt_target](#dbt_target-_str_)
+    9. [env](#env-dictstr-str)
+    10. [py_cluster, sql_cluster, daily_sql_cluster, bf_cluster](#py_cluster-sql_cluster-daily_sql_cluster-bf_cluster-_str_)
+    11. [maintenance](#maintenance-_dbtafmaintenanceconfig_)
+    12. [tableau_refresh_tasks](#tableau_refresh_tasks-_listtableaurefreshtaskconfig_)
 
 ## dbt model config options
 
@@ -30,6 +32,22 @@ Tag to define the schedule of the model. Supported tags are:
 - **@every15minutes** model will be run every 15 minutes (equals to `*/15 * * * *` cron schedule)
 - **@manual** - special tag to mark the model has no schedule. Read more about it
   in [tutorial](../examples/manual_scheduling.md)
+
+###### schedule_shift (_str_)
+
+Shift the schedule of the model for N units. 
+Unit is parameterized by [schedule_shift_unit](#schedule_shift_unit-_str_).
+
+Resulted airflow DAG will have name `<domain>_<schedule>_shift_<schedule_shift>_<schedule_shift_unit>s`.
+
+###### schedule_shift_unit (_str_)
+
+Schedule shift unit. Supported units are:
+
+- **minute**
+- **hour**
+- **day**
+- **week**
 
 ###### dependencies (_dict[str, DependencyConfig]_)
 

--- a/tests/airflow_dags/conftest.py
+++ b/tests/airflow_dags/conftest.py
@@ -526,3 +526,12 @@ def dags_domain_with_shift(compiled_main_dags):
     """
     with compiled_main_dags('domain_w_shift') as dags:
         yield dags
+
+
+@pytest.fixture
+def dags_two_domains_with_diff_scheduling_and_shifts(compiled_main_dags):
+    """
+    A1@hourly_shift_10_minutes -> B1@daily_shift_2_hours
+    """
+    with compiled_main_dags('two_domains_with_diff_scheduling_and_shifts') as dags:
+        yield dags

--- a/tests/airflow_dags/conftest.py
+++ b/tests/airflow_dags/conftest.py
@@ -512,3 +512,17 @@ def dags_domain_model_w_maintenance(compiled_main_dags):
 def dags_task_with_tableau_integration(compiled_main_dags):
     with compiled_main_dags('task_with_tableau_integration', with_tableau=True) as dags:
         yield dags
+
+
+@pytest.fixture
+def dags_domain_with_shift(compiled_main_dags):
+    """
+    A1@every15minutes_shift_3_minutes
+    A2@hourly_shift_5_minutes
+    A3@daily_shift_5_hours
+    A4@weekly_shift_2_days
+    A5@monthly_shift_2_days
+    A6@monthly_shift_1_days_6_hours
+    """
+    with compiled_main_dags('domain_w_shift') as dags:
+        yield dags

--- a/tests/airflow_dags/fixtures/domain_w_shift/models.yml
+++ b/tests/airflow_dags/fixtures/domain_w_shift/models.yml
@@ -1,0 +1,16 @@
++description: |
+  one domain, 6 nodes with different schedules and shifts
+  
+  A1@every15minutes_shift_3_minutes
+  A2@hourly_shift_5_minutes
+  A3@daily_shift_5_hours
+  A4@weekly_shift_2_days
+  A5@monthly_shift_2_days
+  A6@monthly_shift_1_days_6_hours
+
+    
+    
+    
+    
+    
+    

--- a/tests/airflow_dags/fixtures/domain_w_shift/models/a/raw/a1.sql
+++ b/tests/airflow_dags/fixtures/domain_w_shift/models/a/raw/a1.sql
@@ -1,0 +1,15 @@
+{{ config(
+    materialized='table',
+    file_format='delta',
+    unique_key='id',
+    schedule='@every15minutes',
+    schedule_shift=3,
+    schedule_shift_unit='minute'
+) }}
+
+
+select  1 as id, 'a' as val
+union all
+select 2 as id, 'b' as val
+union all
+select 3 as id, 'c' as val

--- a/tests/airflow_dags/fixtures/domain_w_shift/models/a/raw/a2.sql
+++ b/tests/airflow_dags/fixtures/domain_w_shift/models/a/raw/a2.sql
@@ -1,0 +1,15 @@
+{{ config(
+    materialized='table',
+    file_format='delta',
+    unique_key='id',
+    schedule='@hourly',
+    schedule_shift=5,
+    schedule_shift_unit='minute'
+) }}
+
+
+select  1 as id, 'a' as val
+union all
+select 2 as id, 'b' as val
+union all
+select 3 as id, 'c' as val

--- a/tests/airflow_dags/fixtures/domain_w_shift/models/a/raw/a3.sql
+++ b/tests/airflow_dags/fixtures/domain_w_shift/models/a/raw/a3.sql
@@ -1,0 +1,15 @@
+{{ config(
+    materialized='table',
+    file_format='delta',
+    unique_key='id',
+    schedule='@daily',
+    schedule_shift=5,
+    schedule_shift_unit='hour'
+) }}
+
+
+select  1 as id, 'a' as val
+union all
+select 2 as id, 'b' as val
+union all
+select 3 as id, 'c' as val

--- a/tests/airflow_dags/fixtures/domain_w_shift/models/a/raw/a4.sql
+++ b/tests/airflow_dags/fixtures/domain_w_shift/models/a/raw/a4.sql
@@ -1,0 +1,15 @@
+{{ config(
+    materialized='table',
+    file_format='delta',
+    unique_key='id',
+    schedule='@weekly',
+    schedule_shift=2,
+    schedule_shift_unit='day'
+) }}
+
+
+select  1 as id, 'a' as val
+union all
+select 2 as id, 'b' as val
+union all
+select 3 as id, 'c' as val

--- a/tests/airflow_dags/fixtures/domain_w_shift/models/a/raw/a5.sql
+++ b/tests/airflow_dags/fixtures/domain_w_shift/models/a/raw/a5.sql
@@ -1,0 +1,15 @@
+{{ config(
+    materialized='table',
+    file_format='delta',
+    unique_key='id',
+    schedule='@monthly',
+    schedule_shift=2,
+    schedule_shift_unit='day'
+) }}
+
+
+select  1 as id, 'a' as val
+union all
+select 2 as id, 'b' as val
+union all
+select 3 as id, 'c' as val

--- a/tests/airflow_dags/fixtures/domain_w_shift/models/a/raw/a6.sql
+++ b/tests/airflow_dags/fixtures/domain_w_shift/models/a/raw/a6.sql
@@ -1,0 +1,15 @@
+{{ config(
+    materialized='table',
+    file_format='delta',
+    unique_key='id',
+    schedule='@monthly',
+    schedule_shift=30,
+    schedule_shift_unit='hour'
+) }}
+
+
+select  1 as id, 'a' as val
+union all
+select 2 as id, 'b' as val
+union all
+select 3 as id, 'c' as val

--- a/tests/airflow_dags/fixtures/two_domains_with_diff_scheduling_and_shifts/models.yml
+++ b/tests/airflow_dags/fixtures/two_domains_with_diff_scheduling_and_shifts/models.yml
@@ -1,0 +1,8 @@
++description: |
+  two domains with different scheduling and shifts
+  A1@hourly_shift_10_minutes -> B1@daily_shift_2_hours
+
+a:
+  +tags: 'a'
+b:
+  +tags: 'b'

--- a/tests/airflow_dags/fixtures/two_domains_with_diff_scheduling_and_shifts/models/a/ods/a1.sql
+++ b/tests/airflow_dags/fixtures/two_domains_with_diff_scheduling_and_shifts/models/a/ods/a1.sql
@@ -1,0 +1,15 @@
+{{ config(
+    materialized='table',
+    file_format='delta',
+    unique_key='id',
+    schedule='@hourly',
+    schedule_shift=10,
+    schedule_shift_unit='minute'
+) }}
+
+
+select  1 as id, 'a' as val
+union all
+select 2 as id, 'b' as val
+union all
+select 3 as id, 'c' as val

--- a/tests/airflow_dags/fixtures/two_domains_with_diff_scheduling_and_shifts/models/b/cdm/b1.sql
+++ b/tests/airflow_dags/fixtures/two_domains_with_diff_scheduling_and_shifts/models/b/cdm/b1.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='table',
+    file_format='delta',
+    unique_key='id',
+    schedule='@daily',
+    schedule_shift=2,
+    schedule_shift_unit='hour'
+) }}
+
+
+select *
+from {{ ref('a1') }}

--- a/tests/airflow_dags/test_dag_build.py
+++ b/tests/airflow_dags/test_dag_build.py
@@ -705,3 +705,34 @@ def test_domain_with_shift(
 
     if run_airflow_tasks:
         run_all_tasks_in_dag(dags)
+
+
+def test_two_domains_with_diff_scheduling_and_shifts(
+    dags_two_domains_with_diff_scheduling_and_shifts,
+    run_airflow_tasks,
+):
+    dags = dags_two_domains_with_diff_scheduling_and_shifts
+
+    assert sorted(dags) == [
+        'a__backfill',
+        'a__hourly_shift_10_minutes',
+        'b__backfill',
+        'b__daily_shift_2_hours',
+    ]
+
+    a_hourly = dags['a__hourly_shift_10_minutes']
+    b_daily = dags['b__daily_shift_2_hours']
+
+    assert a_hourly.dag_id == 'a__hourly_shift_10_minutes'
+    assert sorted(a_hourly.task_ids) == ['a1']
+    assert node_ids(a_hourly.task_dict['a1'].upstream_list) == []
+
+    assert b_daily.dag_id == 'b__daily_shift_2_hours'
+    assert sorted(b_daily.task_ids) == ['a__hourly_shift_10_minutes__dependencies__group.wait__a1', 'b1']
+    assert node_ids(b_daily.task_dict['a__hourly_shift_10_minutes__dependencies__group.wait__a1'].upstream_list) == []
+    assert node_ids(b_daily.task_dict['b1'].upstream_list) == [
+        'a__hourly_shift_10_minutes__dependencies__group.wait__a1'
+    ]
+
+    if run_airflow_tasks:
+        run_all_tasks_in_dag(dags)

--- a/tests/airflow_dags/test_dag_build.py
+++ b/tests/airflow_dags/test_dag_build.py
@@ -665,3 +665,43 @@ def test_task_with_tableau_integration_has_correct_dags(dags_task_with_tableau_i
 
     if run_airflow_tasks:
         run_all_tasks_in_dag(dags, additional_expected_ti_states=(TaskInstanceState.SKIPPED,))
+
+
+def test_domain_with_shift(
+    dags_domain_with_shift,
+    run_airflow_tasks,
+):
+    dags = dags_domain_with_shift
+
+    assert sorted(dags) == [
+        'a__backfill',
+        'a__daily_shift_5_hours',
+        'a__every15minutes_shift_3_minutes',
+        'a__hourly_shift_5_minutes',
+        'a__monthly_shift_1_days_6_hours',
+        'a__monthly_shift_2_days',
+        'a__weekly_shift_2_days',
+    ]
+    a1 = dags['a__every15minutes_shift_3_minutes']
+    a2 = dags['a__hourly_shift_5_minutes']
+    a3 = dags['a__daily_shift_5_hours']
+    a4 = dags['a__weekly_shift_2_days']
+    a5 = dags['a__monthly_shift_2_days']
+    a6 = dags['a__monthly_shift_1_days_6_hours']
+
+    assert a1.dag_id == 'a__every15minutes_shift_3_minutes'
+    assert sorted(a1.task_ids) == ['a1']
+    assert node_ids(a1.task_dict['a1'].upstream_list) == []
+
+    assert a2.dag_id == 'a__hourly_shift_5_minutes'
+
+    assert a3.dag_id == 'a__daily_shift_5_hours'
+
+    assert a4.dag_id == 'a__weekly_shift_2_days'
+
+    assert a5.dag_id == 'a__monthly_shift_2_days'
+
+    assert a6.dag_id == 'a__monthly_shift_1_days_6_hours'
+
+    if run_airflow_tasks:
+        run_all_tasks_in_dag(dags)

--- a/tests/test_scheduling_tags.py
+++ b/tests/test_scheduling_tags.py
@@ -3,14 +3,14 @@ import datetime
 import pytest
 
 from dbt_af.common.scheduling import (
-    ScheduleTag,
+    BaseScheduleTag,
+    EScheduleTag,
     _DailyScheduleTag,
     _HourlyScheduleTag,
     _ManualScheduleTag,
     _MonthlyScheduleTag,
     _WeeklyScheduleTag,
 )
-from dbt_af.operators.sensors import get_base_schedule_name
 
 
 def test_manual_schedule_tag():
@@ -18,7 +18,8 @@ def test_manual_schedule_tag():
     assert _ManualScheduleTag().name == '@manual'
     assert _ManualScheduleTag().safe_name == 'dbt_manual'
     assert _ManualScheduleTag().timeshift is None
-    assert _ManualScheduleTag(datetime.timedelta(days=1)).timeshift is None
+    with pytest.raises(ValueError):
+        _ManualScheduleTag(datetime.timedelta(days=1))
 
 
 def test_hourly_schedule_tag():
@@ -142,23 +143,54 @@ def test_monthly_schedule_tag():
 
 
 def test_scheduling_tag_levels_all_unique():
-    all_levels = [tag().level for tag in ScheduleTag]
+    all_levels = [tag().level for tag in EScheduleTag]
     assert len(all_levels) == len(set(all_levels))
 
 
 def test_scheduling_tag_correct_comparison():
     assert (
-        ScheduleTag.manual()
-        < ScheduleTag.every15minutes()
-        < ScheduleTag.hourly()
-        < ScheduleTag.daily()
-        < ScheduleTag.weekly()
-        < ScheduleTag.monthly()
+        EScheduleTag.manual()
+        < EScheduleTag.every15minutes()
+        < EScheduleTag.hourly()
+        < EScheduleTag.daily()
+        < EScheduleTag.weekly()
+        < EScheduleTag.monthly()
     )
 
 
-def test_base_schedule_name():
-    assert get_base_schedule_name(_HourlyScheduleTag(datetime.timedelta(minutes=22))) == '@hourly'
-    assert get_base_schedule_name(_DailyScheduleTag(datetime.timedelta(minutes=22, hours=5))) == '@daily'
-    assert get_base_schedule_name(_WeeklyScheduleTag(datetime.timedelta(minutes=22, hours=5, days=3))) == '@weekly'
-    assert get_base_schedule_name(_MonthlyScheduleTag(datetime.timedelta(minutes=22, hours=5, days=3))) == '@monthly'
+@pytest.mark.parametrize(
+    'schedule_tag, shift, base_name, full_name, expected_error_raise',
+    [
+        ('manual', None, '@manual', '@manual', False),
+        ('manual', datetime.timedelta(minutes=22), '@manual', '', True),
+        ('every15minutes', None, '@every15minutes', '@every15minutes', False),
+        (
+            'every15minutes',
+            datetime.timedelta(minutes=14),
+            '@every15minutes',
+            '@every15minutes_shift_14_minutes',
+            False,
+        ),
+        ('every15minutes', datetime.timedelta(minutes=16), '@every15minutes', '', True),
+        ('hourly', None, '@hourly', '@hourly', False),
+        ('hourly', datetime.timedelta(minutes=22), '@hourly', '@hourly_shift_22_minutes', False),
+        ('hourly', datetime.timedelta(minutes=61), '@hourly', '', True),
+        ('daily', None, '@daily', '@daily', False),
+        ('daily', datetime.timedelta(minutes=22), '@daily', '@daily_shift_22_minutes', False),
+        ('daily', datetime.timedelta(hours=25), '@daily', '', True),
+        ('weekly', None, '@weekly', '@weekly', False),
+        ('weekly', datetime.timedelta(minutes=22), '@weekly', '@weekly_shift_22_minutes', False),
+        ('weekly', datetime.timedelta(days=8), '@weekly', '', True),
+        ('monthly', None, '@monthly', '@monthly', False),
+        ('monthly', datetime.timedelta(minutes=22), '@monthly', '@monthly_shift_22_minutes', False),
+        ('monthly', datetime.timedelta(days=50), '@monthly', '', True),
+    ],
+)
+def test_base_schedule_name(schedule_tag, shift, base_name, full_name, expected_error_raise):
+    if expected_error_raise:
+        with pytest.raises(ValueError):
+            EScheduleTag[schedule_tag](shift)
+    else:
+        schedule: BaseScheduleTag = EScheduleTag[schedule_tag](shift)  # noqa
+        assert schedule.base_name == base_name
+        assert schedule.name == full_name

--- a/tests/test_scheduling_tags.py
+++ b/tests/test_scheduling_tags.py
@@ -10,6 +10,7 @@ from dbt_af.common.scheduling import (
     _MonthlyScheduleTag,
     _WeeklyScheduleTag,
 )
+from dbt_af.operators.sensors import get_base_schedule_name
 
 
 def test_manual_schedule_tag():
@@ -154,3 +155,10 @@ def test_scheduling_tag_correct_comparison():
         < ScheduleTag.weekly()
         < ScheduleTag.monthly()
     )
+
+
+def test_base_schedule_name():
+    assert get_base_schedule_name(_HourlyScheduleTag(datetime.timedelta(minutes=22))) == '@hourly'
+    assert get_base_schedule_name(_DailyScheduleTag(datetime.timedelta(minutes=22, hours=5))) == '@daily'
+    assert get_base_schedule_name(_WeeklyScheduleTag(datetime.timedelta(minutes=22, hours=5, days=3))) == '@weekly'
+    assert get_base_schedule_name(_MonthlyScheduleTag(datetime.timedelta(minutes=22, hours=5, days=3))) == '@monthly'

--- a/tests/test_scheduling_tags.py
+++ b/tests/test_scheduling_tags.py
@@ -31,6 +31,11 @@ def test_hourly_schedule_tag():
     assert _HourlyScheduleTag(datetime.timedelta(minutes=59)).timeshift == datetime.timedelta(minutes=59)
     assert _HourlyScheduleTag(datetime.timedelta(minutes=59)).af_repr() == '59 * * * *'
 
+    assert (
+        _HourlyScheduleTag(datetime.timedelta(minutes=22)).name
+        == '@hourly_shift_22_minutes'
+    )
+
     bad_timeshifts = [
         datetime.timedelta(minutes=60),
         datetime.timedelta(minutes=61),
@@ -56,6 +61,19 @@ def test_daily_schedule_tag():
 
     assert _DailyScheduleTag(datetime.timedelta(hours=23)).timeshift == datetime.timedelta(hours=23)
     assert _DailyScheduleTag(datetime.timedelta(hours=23)).af_repr() == '0 23 * * *'
+
+    assert (
+        _DailyScheduleTag(datetime.timedelta(minutes=22)).name
+        == '@daily_shift_22_minutes'
+    )
+    assert (
+        _DailyScheduleTag(datetime.timedelta(hours=5)).name
+        == '@daily_shift_5_hours'
+    )
+    assert (
+        _DailyScheduleTag(datetime.timedelta(minutes=22, hours=5)).name
+        == '@daily_shift_5_hours_22_minutes'
+    )
 
     bad_timeshifts = [
         datetime.timedelta(hours=24),
@@ -83,6 +101,23 @@ def test_weekly_schedule_tag():
 
     assert _WeeklyScheduleTag(datetime.timedelta(minutes=22, hours=5, days=3)).af_repr() == '22 5 * * 3'
 
+    assert (
+        _WeeklyScheduleTag(datetime.timedelta(minutes=22)).name
+        == '@weekly_shift_22_minutes'
+    )
+    assert (
+        _WeeklyScheduleTag(datetime.timedelta(hours=5)).name
+        == '@weekly_shift_5_hours'
+    )
+    assert (
+        _WeeklyScheduleTag(datetime.timedelta(days=3)).name
+        == '@weekly_shift_3_days'
+    )
+    assert (
+        _WeeklyScheduleTag(datetime.timedelta(minutes=22, hours=5, days=3)).name
+        == '@weekly_shift_3_days_5_hours_22_minutes'
+    )
+
     bad_timeshifts = [
         datetime.timedelta(days=7),
         datetime.timedelta(days=8),
@@ -106,6 +141,23 @@ def test_monthly_schedule_tag():
     assert _MonthlyScheduleTag(datetime.timedelta(days=30)).af_repr() == '0 0 30 * *'
 
     assert _MonthlyScheduleTag(datetime.timedelta(minutes=22, hours=5, days=3)).af_repr() == '22 5 3 * *'
+
+    assert (
+        _MonthlyScheduleTag(datetime.timedelta(minutes=22)).name
+        == '@monthly_shift_22_minutes'
+    )
+    assert (
+        _MonthlyScheduleTag(datetime.timedelta(hours=5)).name
+        == '@monthly_shift_5_hours'
+    )
+    assert (
+        _MonthlyScheduleTag(datetime.timedelta(days=3)).name
+        == '@monthly_shift_3_days'
+    )
+    assert (
+        _MonthlyScheduleTag(datetime.timedelta(minutes=22, hours=5, days=3)).name
+        == '@monthly_shift_3_days_5_hours_22_minutes'
+    )
 
     bad_timeshifts = [
         datetime.timedelta(days=32),

--- a/tests/test_scheduling_tags.py
+++ b/tests/test_scheduling_tags.py
@@ -31,10 +31,7 @@ def test_hourly_schedule_tag():
     assert _HourlyScheduleTag(datetime.timedelta(minutes=59)).timeshift == datetime.timedelta(minutes=59)
     assert _HourlyScheduleTag(datetime.timedelta(minutes=59)).af_repr() == '59 * * * *'
 
-    assert (
-        _HourlyScheduleTag(datetime.timedelta(minutes=22)).name
-        == '@hourly_shift_22_minutes'
-    )
+    assert _HourlyScheduleTag(datetime.timedelta(minutes=22)).name == '@hourly_shift_22_minutes'
 
     bad_timeshifts = [
         datetime.timedelta(minutes=60),
@@ -62,18 +59,9 @@ def test_daily_schedule_tag():
     assert _DailyScheduleTag(datetime.timedelta(hours=23)).timeshift == datetime.timedelta(hours=23)
     assert _DailyScheduleTag(datetime.timedelta(hours=23)).af_repr() == '0 23 * * *'
 
-    assert (
-        _DailyScheduleTag(datetime.timedelta(minutes=22)).name
-        == '@daily_shift_22_minutes'
-    )
-    assert (
-        _DailyScheduleTag(datetime.timedelta(hours=5)).name
-        == '@daily_shift_5_hours'
-    )
-    assert (
-        _DailyScheduleTag(datetime.timedelta(minutes=22, hours=5)).name
-        == '@daily_shift_5_hours_22_minutes'
-    )
+    assert _DailyScheduleTag(datetime.timedelta(minutes=22)).name == '@daily_shift_22_minutes'
+    assert _DailyScheduleTag(datetime.timedelta(hours=5)).name == '@daily_shift_5_hours'
+    assert _DailyScheduleTag(datetime.timedelta(minutes=22, hours=5)).name == '@daily_shift_5_hours_22_minutes'
 
     bad_timeshifts = [
         datetime.timedelta(hours=24),
@@ -101,18 +89,9 @@ def test_weekly_schedule_tag():
 
     assert _WeeklyScheduleTag(datetime.timedelta(minutes=22, hours=5, days=3)).af_repr() == '22 5 * * 3'
 
-    assert (
-        _WeeklyScheduleTag(datetime.timedelta(minutes=22)).name
-        == '@weekly_shift_22_minutes'
-    )
-    assert (
-        _WeeklyScheduleTag(datetime.timedelta(hours=5)).name
-        == '@weekly_shift_5_hours'
-    )
-    assert (
-        _WeeklyScheduleTag(datetime.timedelta(days=3)).name
-        == '@weekly_shift_3_days'
-    )
+    assert _WeeklyScheduleTag(datetime.timedelta(minutes=22)).name == '@weekly_shift_22_minutes'
+    assert _WeeklyScheduleTag(datetime.timedelta(hours=5)).name == '@weekly_shift_5_hours'
+    assert _WeeklyScheduleTag(datetime.timedelta(days=3)).name == '@weekly_shift_3_days'
     assert (
         _WeeklyScheduleTag(datetime.timedelta(minutes=22, hours=5, days=3)).name
         == '@weekly_shift_3_days_5_hours_22_minutes'
@@ -142,18 +121,9 @@ def test_monthly_schedule_tag():
 
     assert _MonthlyScheduleTag(datetime.timedelta(minutes=22, hours=5, days=3)).af_repr() == '22 5 3 * *'
 
-    assert (
-        _MonthlyScheduleTag(datetime.timedelta(minutes=22)).name
-        == '@monthly_shift_22_minutes'
-    )
-    assert (
-        _MonthlyScheduleTag(datetime.timedelta(hours=5)).name
-        == '@monthly_shift_5_hours'
-    )
-    assert (
-        _MonthlyScheduleTag(datetime.timedelta(days=3)).name
-        == '@monthly_shift_3_days'
-    )
+    assert _MonthlyScheduleTag(datetime.timedelta(minutes=22)).name == '@monthly_shift_22_minutes'
+    assert _MonthlyScheduleTag(datetime.timedelta(hours=5)).name == '@monthly_shift_5_hours'
+    assert _MonthlyScheduleTag(datetime.timedelta(days=3)).name == '@monthly_shift_3_days'
     assert (
         _MonthlyScheduleTag(datetime.timedelta(minutes=22, hours=5, days=3)).name
         == '@monthly_shift_3_days_5_hours_22_minutes'

--- a/tests/test_sensors_wait_fns.py
+++ b/tests/test_sensors_wait_fns.py
@@ -364,3 +364,23 @@ def test_daily_on_monthly(execution_date_during_the_day, execution_date_during_t
     assert fn_set_all[0](execution_date_during_the_night) == datetime(2023, 9, 1, 0, 0, 0)
 
     assert fn_set_last[0](execution_date_during_the_night + timedelta(days=6)) == datetime(2023, 9, 1, 0, 0, 0)
+
+
+def test_hourly_with_shift_15_m_on_hourly_with_shift_30_m(
+    execution_date_during_the_day, execution_date_during_the_night
+):
+    assert calculate_task_to_wait_execution_date(
+        datetime(2023, 10, 12, 16, 15, 0),
+        self_schedule=_HourlyScheduleTag(timedelta(minutes=15)),
+        upstream_schedule=_HourlyScheduleTag(timedelta(minutes=30)),
+    ) == datetime(2023, 10, 12, 15, 30, 0)
+
+
+def test_hourly_with_shift_30_m_on_hourly_with_shift_15_m(
+    execution_date_during_the_day, execution_date_during_the_night
+):
+    assert calculate_task_to_wait_execution_date(
+        datetime(2023, 10, 12, 16, 30, 0),
+        self_schedule=_HourlyScheduleTag(timedelta(minutes=30)),
+        upstream_schedule=_HourlyScheduleTag(timedelta(minutes=15)),
+    ) == datetime(2023, 10, 12, 16, 15, 0)

--- a/tests/test_sensors_wait_fns.py
+++ b/tests/test_sensors_wait_fns.py
@@ -412,6 +412,12 @@ def test_hourly_with_shift_30_m_on_hourly_with_shift_15_m():
             datetime(2023, 10, 12, 16, 30, 0),
             datetime(2023, 10, 12, 16, 0, 0),
         ),
+        (
+            _HourlyScheduleTag(timedelta(minutes=30)),
+            _HourlyScheduleTag(timedelta(minutes=30)),
+            datetime(2023, 10, 12, 16, 30, 0),
+            datetime(2023, 10, 12, 16, 30, 0),
+        ),
         # daily
         (
             _DailyScheduleTag(),
@@ -431,6 +437,12 @@ def test_hourly_with_shift_30_m_on_hourly_with_shift_15_m():
             datetime(2023, 10, 12, 3, 0, 0),
             datetime(2023, 10, 12, 0, 0, 0),
         ),
+        (
+            _DailyScheduleTag(timedelta(hours=3)),
+            _DailyScheduleTag(timedelta(hours=3)),
+            datetime(2023, 10, 12, 3, 0, 0),
+            datetime(2023, 10, 12, 3, 0, 0),
+        ),
         # monthly
         (
             _MonthlyScheduleTag(),
@@ -449,6 +461,12 @@ def test_hourly_with_shift_30_m_on_hourly_with_shift_15_m():
             _MonthlyScheduleTag(timedelta(days=7)),
             datetime(2023, 10, 7, 0, 0, 0),
             datetime(2023, 10, 1, 0, 0, 0),
+        ),
+        (
+            _MonthlyScheduleTag(timedelta(days=7)),
+            _MonthlyScheduleTag(timedelta(days=7)),
+            datetime(2023, 10, 7, 0, 0, 0),
+            datetime(2023, 10, 7, 0, 0, 0),
         ),
     ],
 )

--- a/tests/test_sensors_wait_fns.py
+++ b/tests/test_sensors_wait_fns.py
@@ -388,3 +388,78 @@ def test_hourly_with_shift_30_m_on_hourly_with_shift_15_m():
         self_schedule=_HourlyScheduleTag(timedelta(minutes=30)),
         upstream_schedule=_HourlyScheduleTag(timedelta(minutes=15)),
     ) == datetime(2023, 10, 12, 16, 15, 0)
+
+
+@pytest.mark.parametrize(
+    'upstream_schedule, downstream_schedule, execution_date, expected_wait_execution_date',
+    [
+        # hourly
+        (
+            _HourlyScheduleTag(),
+            _HourlyScheduleTag(),
+            datetime(2023, 10, 12, 16, 0, 0),
+            datetime(2023, 10, 12, 16, 0, 0),
+        ),
+        (
+            _HourlyScheduleTag(timedelta(minutes=30)),
+            _HourlyScheduleTag(),
+            datetime(2023, 10, 12, 16, 0, 0),
+            datetime(2023, 10, 12, 15, 30, 0),
+        ),
+        (
+            _HourlyScheduleTag(),
+            _HourlyScheduleTag(timedelta(minutes=30)),
+            datetime(2023, 10, 12, 16, 30, 0),
+            datetime(2023, 10, 12, 16, 0, 0),
+        ),
+        # daily
+        (
+            _DailyScheduleTag(),
+            _DailyScheduleTag(),
+            datetime(2023, 10, 12, 0, 0, 0),
+            datetime(2023, 10, 12, 0, 0, 0),
+        ),
+        (
+            _DailyScheduleTag(timedelta(hours=3)),
+            _DailyScheduleTag(),
+            datetime(2023, 10, 12, 0, 0, 0),
+            datetime(2023, 10, 11, 3, 0, 0),
+        ),
+        (
+            _DailyScheduleTag(),
+            _DailyScheduleTag(timedelta(hours=3)),
+            datetime(2023, 10, 12, 3, 0, 0),
+            datetime(2023, 10, 12, 0, 0, 0),
+        ),
+        # monthly
+        (
+            _MonthlyScheduleTag(),
+            _MonthlyScheduleTag(),
+            datetime(2023, 10, 1, 0, 0, 0),
+            datetime(2023, 10, 1, 0, 0, 0),
+        ),
+        (
+            _MonthlyScheduleTag(timedelta(days=7)),
+            _MonthlyScheduleTag(),
+            datetime(2023, 10, 1, 0, 0, 0),
+            datetime(2023, 9, 7, 0, 0, 0),
+        ),
+        (
+            _MonthlyScheduleTag(),
+            _MonthlyScheduleTag(timedelta(days=7)),
+            datetime(2023, 10, 7, 0, 0, 0),
+            datetime(2023, 10, 1, 0, 0, 0),
+        ),
+    ],
+)
+def test_schedule_on_same_schedule(
+    upstream_schedule, downstream_schedule, execution_date, expected_wait_execution_date
+):
+    assert (
+        calculate_task_to_wait_execution_date(
+            execution_date,
+            self_schedule=downstream_schedule,
+            upstream_schedule=upstream_schedule,
+        )
+        == expected_wait_execution_date
+    )

--- a/tests/test_sensors_wait_fns.py
+++ b/tests/test_sensors_wait_fns.py
@@ -366,9 +366,11 @@ def test_daily_on_monthly(execution_date_during_the_day, execution_date_during_t
     assert fn_set_last[0](execution_date_during_the_night + timedelta(days=6)) == datetime(2023, 9, 1, 0, 0, 0)
 
 
-def test_hourly_with_shift_15_m_on_hourly_with_shift_30_m(
-    execution_date_during_the_day, execution_date_during_the_night
-):
+def test_hourly_with_shift_15_m_on_hourly_with_shift_30_m():
+    """
+    @hourly_shift_15_minutes with an interval [16:15, 17:15]
+    waits for @hourly_shift_30_minutes with an interval [15:30, 16:30]
+    """
     assert calculate_task_to_wait_execution_date(
         datetime(2023, 10, 12, 16, 15, 0),
         self_schedule=_HourlyScheduleTag(timedelta(minutes=15)),
@@ -376,9 +378,11 @@ def test_hourly_with_shift_15_m_on_hourly_with_shift_30_m(
     ) == datetime(2023, 10, 12, 15, 30, 0)
 
 
-def test_hourly_with_shift_30_m_on_hourly_with_shift_15_m(
-    execution_date_during_the_day, execution_date_during_the_night
-):
+def test_hourly_with_shift_30_m_on_hourly_with_shift_15_m():
+    """
+    @hourly_shift_30_minutes with an interval [16:30, 17:30]
+    waits for @hourly_shift_15_minutes with an interval [16:15, 17:15]
+    """
     assert calculate_task_to_wait_execution_date(
         datetime(2023, 10, 12, 16, 30, 0),
         self_schedule=_HourlyScheduleTag(timedelta(minutes=30)),


### PR DESCRIPTION
# Add possibility to shift schedule matrix

New interface for dbt model's config:
```yml
config:
  schedule: @hourly
  schedule_shift: 30  # any positive integer
  schedule_shift_unit: minute  # any from minute/hour/day/week
```

Resulting airflow DAG name: `<domain>_<schedule>_shift_<schedule_shift>_<schedule_shift_unit>s`