### PR TITLE
feat: add iceberg compatibility

### DIFF
--- a/dbt_af/parser/dbt_node_model.py
+++ b/dbt_af/parser/dbt_node_model.py
@@ -209,7 +209,7 @@ class DbtNodeColumn(pydantic.BaseModel):
 
 
 class DbtNode(pydantic.BaseModel):
-    database: Optional[str]  # for iceberg it is None
+    database: Optional[str]
     node_schema: str = pydantic.Field(..., alias='schema')
     name: str
     resource_type: str

--- a/dbt_af/parser/dbt_node_model.py
+++ b/dbt_af/parser/dbt_node_model.py
@@ -209,7 +209,7 @@ class DbtNodeColumn(pydantic.BaseModel):
 
 
 class DbtNode(pydantic.BaseModel):
-    database: str
+    database: Optional[str]  # for iceberg it is None
     node_schema: str = pydantic.Field(..., alias='schema')
     name: str
     resource_type: str

--- a/dbt_af/parser/dbt_source_model.py
+++ b/dbt_af/parser/dbt_source_model.py
@@ -26,7 +26,7 @@ class DbtSourceConfig(pydantic.BaseModel):
 
 
 class DbtSource(pydantic.BaseModel):
-    database: str
+    database: Optional[str]
     node_schema: Optional[str] = pydantic.Field(..., alias='schema')
     name: str
     resource_type: str


### PR DESCRIPTION
https://docs.getdbt.com/reference/resource-configs/spark-configs#always-schema-never-database

Apache Spark uses the terms "schema" and "database" interchangeably. dbt understands database to exist at a higher level than schema. As such, you should never use or set database as a node config or in the target profile when running dbt-spark.

В случае с dbt-spark падает в ошибку pydantic
решение
поменял на database: Optional[str]